### PR TITLE
Add badge constants and helper methods

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -261,6 +261,116 @@ for _, badgeSet := range resp.Data {
 }
 ```
 
+## Badge Constants and Helpers
+
+The library provides constants for common badge SetIDs and helper functions for working with badges in EventSub chat events.
+
+### Badge Constants
+
+```go
+// Channel role badges
+helix.BadgeBroadcaster   // "broadcaster"
+helix.BadgeModerator     // "moderator"
+helix.BadgeLeadModerator // "lead_moderator"
+helix.BadgeVIP           // "vip"
+
+// Subscription badges
+helix.BadgeSubscriber    // "subscriber"
+helix.BadgeFounder       // "founder"
+helix.BadgeSubGifter     // "sub-gifter"
+
+// Bits badges
+helix.BadgeBits          // "bits"
+helix.BadgeBitsLeader    // "bits-leader"
+
+// Twitch staff badges
+helix.BadgeStaff         // "staff"
+helix.BadgeAdmin         // "admin"
+helix.BadgeGlobalMod     // "global_mod"
+
+// Other badges
+helix.BadgePartner       // "partner"
+helix.BadgePremium       // "premium"
+helix.BadgeArtist        // "artist"
+helix.BadgePredictions   // "predictions"
+helix.BadgeHypeTrain     // "hype-train"
+```
+
+### Lead Moderator Badge
+
+The `lead_moderator` badge was introduced for the Lead Moderator role. Lead Moderators have additional privileges to help streamers manage their mod teams. They can choose to display either the Lead Moderator badge or the regular Moderator badge.
+
+**Important:** If your application checks for the `moderator` badge to confirm moderator privileges, you should update your logic to check for either `moderator` OR `lead_moderator`. Use the `HasModeratorPrivileges()` helper method for this purpose.
+
+### Badge Helper Methods
+
+Convert EventSub badges to use helper methods:
+
+```go
+// In an EventSub chat message handler
+func handleChatMessage(event *helix.ChannelChatMessageEvent) {
+    // Convert badges to use helper methods
+    badges := helix.ToChatEventBadges(event.Badges)
+
+    // Check for moderator privileges (handles both moderator and lead_moderator)
+    if badges.HasModeratorPrivileges() {
+        fmt.Printf("%s is a moderator\n", event.ChatterUserName)
+    }
+
+    // Check for broadcaster
+    if badges.HasBroadcasterPrivileges() {
+        fmt.Printf("%s is the broadcaster\n", event.ChatterUserName)
+    }
+
+    // Check for VIP
+    if badges.HasVIPStatus() {
+        fmt.Printf("%s is a VIP\n", event.ChatterUserName)
+    }
+
+    // Check for subscriber (includes founders)
+    if badges.IsSubscriber() {
+        fmt.Printf("%s is a subscriber\n", event.ChatterUserName)
+    }
+
+    // Check for Twitch staff (staff, admin, global_mod)
+    if badges.IsStaff() {
+        fmt.Printf("%s is Twitch staff\n", event.ChatterUserName)
+    }
+}
+```
+
+### Available Helper Methods
+
+| Method | Description |
+|--------|-------------|
+| `HasBadge(setID)` | Check if user has a specific badge |
+| `HasAnyBadge(setIDs...)` | Check if user has any of the specified badges |
+| `HasModeratorPrivileges()` | Check for `moderator` OR `lead_moderator` badge |
+| `HasBroadcasterPrivileges()` | Check for `broadcaster` badge |
+| `HasVIPStatus()` | Check for `vip` badge |
+| `IsSubscriber()` | Check for `subscriber` OR `founder` badge |
+| `IsStaff()` | Check for `staff`, `admin`, OR `global_mod` badge |
+| `GetBadge(setID)` | Get a specific badge or nil if not found |
+
+### Example: Moderator Check with Lead Moderator Support
+
+```go
+// OLD: Only checks for moderator badge (misses Lead Moderators)
+func isModeratorOld(badges []helix.ChatEventBadge) bool {
+    for _, badge := range badges {
+        if badge.SetID == "moderator" {
+            return true
+        }
+    }
+    return false
+}
+
+// NEW: Properly checks for both moderator and lead_moderator
+func isModeratorNew(badges []helix.ChatEventBadge) bool {
+    return helix.ToChatEventBadges(badges).HasModeratorPrivileges()
+}
+```
+
 ## GetChatSettings
 
 Get chat settings for a broadcaster's chat room.

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -134,6 +134,8 @@ if err != nil {
 
 Get all users allowed to moderate a broadcaster's chat room.
 
+**Note:** This endpoint returns both Moderators and Lead Moderators, as Lead Moderators are also Moderators with additional privileges.
+
 **Requires:** `moderation:read`
 
 ```go

--- a/helix/badges.go
+++ b/helix/badges.go
@@ -1,0 +1,137 @@
+package helix
+
+// Badge SetID constants for common Twitch chat badges.
+// These constants represent the SetID field in ChatEventBadge and ChatBadge types.
+const (
+	// BadgeBroadcaster is the badge for the channel owner.
+	BadgeBroadcaster = "broadcaster"
+
+	// BadgeModerator is the badge for channel moderators.
+	// Note: Users with the Lead Moderator role may display either
+	// BadgeModerator or BadgeLeadModerator depending on their preference.
+	BadgeModerator = "moderator"
+
+	// BadgeLeadModerator is the badge for Lead Moderators.
+	// Lead Moderators have additional privileges to help streamers manage
+	// their mod teams. They can choose to display either this badge or
+	// the regular moderator badge.
+	BadgeLeadModerator = "lead_moderator"
+
+	// BadgeVIP is the badge for channel VIPs.
+	BadgeVIP = "vip"
+
+	// BadgeSubscriber is the badge for channel subscribers.
+	BadgeSubscriber = "subscriber"
+
+	// BadgeFounder is the badge for channel founders (first subscribers).
+	BadgeFounder = "founder"
+
+	// BadgeSubGifter is the badge for users who have gifted subscriptions.
+	BadgeSubGifter = "sub-gifter"
+
+	// BadgeBitsLeader is the badge for bits leaderboard leaders.
+	BadgeBitsLeader = "bits-leader"
+
+	// BadgeBits is the badge showing bits tier.
+	BadgeBits = "bits"
+
+	// BadgePremium is the badge for Twitch Prime/Turbo users.
+	BadgePremium = "premium"
+
+	// BadgePartner is the badge for Twitch Partners.
+	BadgePartner = "partner"
+
+	// BadgeStaff is the badge for Twitch Staff.
+	BadgeStaff = "staff"
+
+	// BadgeAdmin is the badge for Twitch Admins.
+	BadgeAdmin = "admin"
+
+	// BadgeGlobalMod is the badge for Twitch Global Moderators.
+	BadgeGlobalMod = "global_mod"
+
+	// BadgeArtist is the badge for channel artists.
+	BadgeArtist = "artist"
+
+	// BadgeNoAudio is the badge indicating the user has no audio.
+	BadgeNoAudio = "no_audio"
+
+	// BadgeNoVideo is the badge indicating the user has no video.
+	BadgeNoVideo = "no_video"
+
+	// BadgePredictions is the badge for prediction participation.
+	BadgePredictions = "predictions"
+
+	// BadgeHypeTrain is the badge for Hype Train participation.
+	BadgeHypeTrain = "hype-train"
+)
+
+// ChatEventBadges is a slice of ChatEventBadge with helper methods.
+type ChatEventBadges []ChatEventBadge
+
+// HasBadge checks if the badges contain a specific badge SetID.
+func (badges ChatEventBadges) HasBadge(setID string) bool {
+	for _, badge := range badges {
+		if badge.SetID == setID {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAnyBadge checks if the badges contain any of the specified badge SetIDs.
+func (badges ChatEventBadges) HasAnyBadge(setIDs ...string) bool {
+	setIDMap := make(map[string]struct{}, len(setIDs))
+	for _, id := range setIDs {
+		setIDMap[id] = struct{}{}
+	}
+	for _, badge := range badges {
+		if _, ok := setIDMap[badge.SetID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// HasModeratorPrivileges checks if the user has moderator privileges.
+// This returns true if the user has either the "moderator" or "lead_moderator" badge.
+// Use this method instead of checking only for BadgeModerator to properly support
+// Lead Moderators who may display either badge.
+func (badges ChatEventBadges) HasModeratorPrivileges() bool {
+	return badges.HasAnyBadge(BadgeModerator, BadgeLeadModerator)
+}
+
+// HasBroadcasterPrivileges checks if the user is the broadcaster.
+func (badges ChatEventBadges) HasBroadcasterPrivileges() bool {
+	return badges.HasBadge(BadgeBroadcaster)
+}
+
+// HasVIPStatus checks if the user is a VIP.
+func (badges ChatEventBadges) HasVIPStatus() bool {
+	return badges.HasBadge(BadgeVIP)
+}
+
+// IsSubscriber checks if the user is a subscriber.
+func (badges ChatEventBadges) IsSubscriber() bool {
+	return badges.HasAnyBadge(BadgeSubscriber, BadgeFounder)
+}
+
+// IsStaff checks if the user is Twitch staff (staff, admin, or global mod).
+func (badges ChatEventBadges) IsStaff() bool {
+	return badges.HasAnyBadge(BadgeStaff, BadgeAdmin, BadgeGlobalMod)
+}
+
+// GetBadge returns the badge with the specified SetID, or nil if not found.
+func (badges ChatEventBadges) GetBadge(setID string) *ChatEventBadge {
+	for i := range badges {
+		if badges[i].SetID == setID {
+			return &badges[i]
+		}
+	}
+	return nil
+}
+
+// ToChatEventBadges converts a []ChatEventBadge to ChatEventBadges for use with helper methods.
+func ToChatEventBadges(badges []ChatEventBadge) ChatEventBadges {
+	return ChatEventBadges(badges)
+}

--- a/helix/badges_test.go
+++ b/helix/badges_test.go
@@ -1,0 +1,334 @@
+package helix
+
+import "testing"
+
+func TestChatEventBadges_HasBadge(t *testing.T) {
+	badges := ChatEventBadges{
+		{SetID: BadgeModerator, ID: "1", Info: ""},
+		{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+	}
+
+	tests := []struct {
+		name   string
+		setID  string
+		expect bool
+	}{
+		{"has moderator badge", BadgeModerator, true},
+		{"has subscriber badge", BadgeSubscriber, true},
+		{"does not have broadcaster badge", BadgeBroadcaster, false},
+		{"does not have VIP badge", BadgeVIP, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := badges.HasBadge(tt.setID); got != tt.expect {
+				t.Errorf("HasBadge(%q) = %v, want %v", tt.setID, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_HasAnyBadge(t *testing.T) {
+	badges := ChatEventBadges{
+		{SetID: BadgeModerator, ID: "1", Info: ""},
+	}
+
+	tests := []struct {
+		name   string
+		setIDs []string
+		expect bool
+	}{
+		{"has one of moderator or broadcaster", []string{BadgeModerator, BadgeBroadcaster}, true},
+		{"has none of VIP or subscriber", []string{BadgeVIP, BadgeSubscriber}, false},
+		{"single match", []string{BadgeModerator}, true},
+		{"empty check", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := badges.HasAnyBadge(tt.setIDs...); got != tt.expect {
+				t.Errorf("HasAnyBadge(%v) = %v, want %v", tt.setIDs, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_HasModeratorPrivileges(t *testing.T) {
+	tests := []struct {
+		name   string
+		badges ChatEventBadges
+		expect bool
+	}{
+		{
+			name: "moderator badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeModerator, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "lead moderator badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeLeadModerator, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "lead moderator with subscriber",
+			badges: ChatEventBadges{
+				{SetID: BadgeLeadModerator, ID: "1", Info: ""},
+				{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+			},
+			expect: true,
+		},
+		{
+			name: "only subscriber",
+			badges: ChatEventBadges{
+				{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+			},
+			expect: false,
+		},
+		{
+			name:   "no badges",
+			badges: ChatEventBadges{},
+			expect: false,
+		},
+		{
+			name: "broadcaster only (not mod)",
+			badges: ChatEventBadges{
+				{SetID: BadgeBroadcaster, ID: "1", Info: ""},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.badges.HasModeratorPrivileges(); got != tt.expect {
+				t.Errorf("HasModeratorPrivileges() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_HasBroadcasterPrivileges(t *testing.T) {
+	tests := []struct {
+		name   string
+		badges ChatEventBadges
+		expect bool
+	}{
+		{
+			name: "broadcaster badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeBroadcaster, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "moderator only",
+			badges: ChatEventBadges{
+				{SetID: BadgeModerator, ID: "1", Info: ""},
+			},
+			expect: false,
+		},
+		{
+			name:   "no badges",
+			badges: ChatEventBadges{},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.badges.HasBroadcasterPrivileges(); got != tt.expect {
+				t.Errorf("HasBroadcasterPrivileges() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_HasVIPStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		badges ChatEventBadges
+		expect bool
+	}{
+		{
+			name: "VIP badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeVIP, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "moderator only",
+			badges: ChatEventBadges{
+				{SetID: BadgeModerator, ID: "1", Info: ""},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.badges.HasVIPStatus(); got != tt.expect {
+				t.Errorf("HasVIPStatus() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_IsSubscriber(t *testing.T) {
+	tests := []struct {
+		name   string
+		badges ChatEventBadges
+		expect bool
+	}{
+		{
+			name: "subscriber badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+			},
+			expect: true,
+		},
+		{
+			name: "founder badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeFounder, ID: "0", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "neither subscriber nor founder",
+			badges: ChatEventBadges{
+				{SetID: BadgeModerator, ID: "1", Info: ""},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.badges.IsSubscriber(); got != tt.expect {
+				t.Errorf("IsSubscriber() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_IsStaff(t *testing.T) {
+	tests := []struct {
+		name   string
+		badges ChatEventBadges
+		expect bool
+	}{
+		{
+			name: "staff badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeStaff, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "admin badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeAdmin, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "global mod badge",
+			badges: ChatEventBadges{
+				{SetID: BadgeGlobalMod, ID: "1", Info: ""},
+			},
+			expect: true,
+		},
+		{
+			name: "regular moderator",
+			badges: ChatEventBadges{
+				{SetID: BadgeModerator, ID: "1", Info: ""},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.badges.IsStaff(); got != tt.expect {
+				t.Errorf("IsStaff() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestChatEventBadges_GetBadge(t *testing.T) {
+	badges := ChatEventBadges{
+		{SetID: BadgeModerator, ID: "1", Info: ""},
+		{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+	}
+
+	t.Run("found badge", func(t *testing.T) {
+		badge := badges.GetBadge(BadgeSubscriber)
+		if badge == nil {
+			t.Fatal("expected to find subscriber badge")
+		}
+		if badge.ID != "12" {
+			t.Errorf("expected badge ID '12', got %q", badge.ID)
+		}
+		if badge.Info != "12" {
+			t.Errorf("expected badge Info '12', got %q", badge.Info)
+		}
+	})
+
+	t.Run("badge not found", func(t *testing.T) {
+		badge := badges.GetBadge(BadgeBroadcaster)
+		if badge != nil {
+			t.Errorf("expected nil, got %+v", badge)
+		}
+	})
+}
+
+func TestToChatEventBadges(t *testing.T) {
+	original := []ChatEventBadge{
+		{SetID: BadgeModerator, ID: "1", Info: ""},
+		{SetID: BadgeSubscriber, ID: "12", Info: "12"},
+	}
+
+	converted := ToChatEventBadges(original)
+
+	if len(converted) != len(original) {
+		t.Errorf("expected length %d, got %d", len(original), len(converted))
+	}
+
+	// Verify helper methods work after conversion
+	if !converted.HasModeratorPrivileges() {
+		t.Error("expected HasModeratorPrivileges() to return true")
+	}
+}
+
+func TestBadgeConstants(t *testing.T) {
+	// Verify badge constants have expected values
+	constants := map[string]string{
+		"BadgeBroadcaster":   BadgeBroadcaster,
+		"BadgeModerator":     BadgeModerator,
+		"BadgeLeadModerator": BadgeLeadModerator,
+		"BadgeVIP":           BadgeVIP,
+		"BadgeSubscriber":    BadgeSubscriber,
+		"BadgeFounder":       BadgeFounder,
+	}
+
+	expected := map[string]string{
+		"BadgeBroadcaster":   "broadcaster",
+		"BadgeModerator":     "moderator",
+		"BadgeLeadModerator": "lead_moderator",
+		"BadgeVIP":           "vip",
+		"BadgeSubscriber":    "subscriber",
+		"BadgeFounder":       "founder",
+	}
+
+	for name, got := range constants {
+		if want := expected[name]; got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add constants for common Twitch chat badge SetIDs (broadcaster, moderator, lead_moderator, vip, subscriber, etc.)
- Add helper methods for working with badges in EventSub chat events
- Add HasModeratorPrivileges() helper to check for moderator or lead_moderator badges
- Update documentation for badge helpers and Lead Moderator support

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
