### PR TITLE
Add IRC/TMI chat client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive Twitch API toolkit for Go.
 - **Complete OAuth Support**: All four Twitch OAuth flows (Implicit, Authorization Code, Client Credentials, Device Code)
 - **Token Management**: Automatic token refresh, validation, and revocation
 - **Comprehensive API Coverage**: 147+ Helix API endpoints supported
+- **IRC/TMI Chat**: Full IRC chat client for building chat bots with message parsing, subs, raids, and moderation events
 - **EventSub Webhooks**: Built-in webhook handler with signature verification and event parsing
 - **EventSub WebSocket**: Real-time event streaming with automatic keepalive and reconnection
 - **Extension JWT**: Full support for Twitch Extension authentication
@@ -67,8 +68,10 @@ func main() {
 ## Comparison
 
 | Feature | Kappopher | Other Helix wrappers |
-|---------|-----------|----------------|
+|---------|-----------|----------------------|
+| IRC/TMI Chat | Yes | Varies |
 | EventSub WebSocket | Yes | No |
+| EventSub Conduits | Yes | Varies |
 | Middleware System | Yes | No |
 | Caching Layer | Yes | No |
 | Batch Operations | Yes | No |

--- a/helix/chat_client.go
+++ b/helix/chat_client.go
@@ -1,0 +1,387 @@
+package helix
+
+import (
+	"context"
+	"sync"
+)
+
+// ChatBotClient provides a high-level interface for Twitch chat bots.
+// It wraps IRCClient with convenience methods and automatic token handling.
+type ChatBotClient struct {
+	irc        *IRCClient
+	authClient *AuthClient
+	nick       string
+
+	// Event handlers
+	onMessage    func(*ChatMessage)
+	onSub        func(*UserNotice)
+	onResub      func(*UserNotice)
+	onSubGift    func(*UserNotice)
+	onRaid       func(*UserNotice)
+	onCheer      func(*ChatMessage)
+	onJoin       func(channel, user string)
+	onPart       func(channel, user string)
+	onRoomState  func(*RoomState)
+	onNotice     func(*Notice)
+	onClearChat  func(*ClearChat)
+	onWhisper    func(*Whisper)
+	onConnect    func()
+	onDisconnect func()
+	onError      func(error)
+
+	mu sync.RWMutex
+}
+
+// ChatBotOption configures the ChatBotClient.
+type ChatBotOption func(*ChatBotClient)
+
+// NewChatBotClient creates a new high-level chat bot client.
+// The nick should be the bot's username, and authClient should have a valid user access token.
+func NewChatBotClient(nick string, authClient *AuthClient, opts ...ChatBotOption) *ChatBotClient {
+	c := &ChatBotClient{
+		authClient: authClient,
+		nick:       nick,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// OnMessage sets the handler for all chat messages.
+func (c *ChatBotClient) OnMessage(fn func(*ChatMessage)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onMessage = fn
+}
+
+// OnSub sets the handler for new subscription events.
+func (c *ChatBotClient) OnSub(fn func(*UserNotice)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onSub = fn
+}
+
+// OnResub sets the handler for resubscription events.
+func (c *ChatBotClient) OnResub(fn func(*UserNotice)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onResub = fn
+}
+
+// OnSubGift sets the handler for gift subscription events.
+func (c *ChatBotClient) OnSubGift(fn func(*UserNotice)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onSubGift = fn
+}
+
+// OnRaid sets the handler for raid events.
+func (c *ChatBotClient) OnRaid(fn func(*UserNotice)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onRaid = fn
+}
+
+// OnCheer sets the handler for cheer (bits) messages.
+func (c *ChatBotClient) OnCheer(fn func(*ChatMessage)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onCheer = fn
+}
+
+// OnJoin sets the handler for user join events.
+func (c *ChatBotClient) OnJoin(fn func(channel, user string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onJoin = fn
+}
+
+// OnPart sets the handler for user part events.
+func (c *ChatBotClient) OnPart(fn func(channel, user string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onPart = fn
+}
+
+// OnRoomState sets the handler for room state changes.
+func (c *ChatBotClient) OnRoomState(fn func(*RoomState)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onRoomState = fn
+}
+
+// OnNotice sets the handler for server notices.
+func (c *ChatBotClient) OnNotice(fn func(*Notice)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onNotice = fn
+}
+
+// OnClearChat sets the handler for chat clear/timeout/ban events.
+func (c *ChatBotClient) OnClearChat(fn func(*ClearChat)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onClearChat = fn
+}
+
+// OnWhisper sets the handler for whisper messages.
+func (c *ChatBotClient) OnWhisper(fn func(*Whisper)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onWhisper = fn
+}
+
+// OnConnect sets the handler for successful connections.
+func (c *ChatBotClient) OnConnect(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onConnect = fn
+}
+
+// OnDisconnect sets the handler for disconnections.
+func (c *ChatBotClient) OnDisconnect(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onDisconnect = fn
+}
+
+// OnError sets the handler for errors.
+func (c *ChatBotClient) OnError(fn func(error)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onError = fn
+}
+
+// Connect establishes a connection to Twitch chat.
+func (c *ChatBotClient) Connect(ctx context.Context) error {
+	token := ""
+	if c.authClient != nil {
+		if t := c.authClient.GetToken(); t != nil {
+			token = t.AccessToken
+		}
+	}
+
+	c.irc = NewIRCClient(c.nick, token,
+		WithMessageHandler(c.handleMessage),
+		WithUserNoticeHandler(c.handleUserNotice),
+		WithJoinHandler(c.handleJoin),
+		WithPartHandler(c.handlePart),
+		WithRoomStateHandler(c.handleRoomState),
+		WithNoticeHandler(c.handleNotice),
+		WithClearChatHandler(c.handleClearChat),
+		WithWhisperHandler(c.handleWhisper),
+		WithConnectHandler(c.handleConnect),
+		WithDisconnectHandler(c.handleDisconnect),
+		WithIRCErrorHandler(c.handleError),
+	)
+
+	return c.irc.Connect(ctx)
+}
+
+// Close closes the chat connection.
+func (c *ChatBotClient) Close() error {
+	if c.irc != nil {
+		return c.irc.Close()
+	}
+	return nil
+}
+
+// IsConnected returns whether the client is connected.
+func (c *ChatBotClient) IsConnected() bool {
+	if c.irc == nil {
+		return false
+	}
+	return c.irc.IsConnected()
+}
+
+// Join joins one or more channels.
+func (c *ChatBotClient) Join(channels ...string) error {
+	if c.irc == nil {
+		return ErrIRCNotConnected
+	}
+	return c.irc.Join(channels...)
+}
+
+// Part leaves one or more channels.
+func (c *ChatBotClient) Part(channels ...string) error {
+	if c.irc == nil {
+		return ErrIRCNotConnected
+	}
+	return c.irc.Part(channels...)
+}
+
+// Say sends a message to a channel.
+func (c *ChatBotClient) Say(channel, message string) error {
+	if c.irc == nil {
+		return ErrIRCNotConnected
+	}
+	return c.irc.Say(channel, message)
+}
+
+// Reply sends a reply to a specific message.
+func (c *ChatBotClient) Reply(channel, parentMsgID, message string) error {
+	if c.irc == nil {
+		return ErrIRCNotConnected
+	}
+	return c.irc.Reply(channel, parentMsgID, message)
+}
+
+// Whisper sends a whisper to a user.
+func (c *ChatBotClient) Whisper(user, message string) error {
+	if c.irc == nil {
+		return ErrIRCNotConnected
+	}
+	return c.irc.Whisper(user, message)
+}
+
+// GetJoinedChannels returns the list of joined channels.
+func (c *ChatBotClient) GetJoinedChannels() []string {
+	if c.irc == nil {
+		return nil
+	}
+	return c.irc.GetJoinedChannels()
+}
+
+// IRC returns the underlying IRC client for advanced usage.
+func (c *ChatBotClient) IRC() *IRCClient {
+	return c.irc
+}
+
+// Internal handlers
+
+func (c *ChatBotClient) handleMessage(msg *ChatMessage) {
+	c.mu.RLock()
+	onMessage := c.onMessage
+	onCheer := c.onCheer
+	c.mu.RUnlock()
+
+	// Check for cheers
+	if msg.Bits > 0 && onCheer != nil {
+		onCheer(msg)
+	}
+
+	if onMessage != nil {
+		onMessage(msg)
+	}
+}
+
+func (c *ChatBotClient) handleUserNotice(notice *UserNotice) {
+	c.mu.RLock()
+	onSub := c.onSub
+	onResub := c.onResub
+	onSubGift := c.onSubGift
+	onRaid := c.onRaid
+	c.mu.RUnlock()
+
+	switch notice.Type {
+	case UserNoticeTypeSub:
+		if onSub != nil {
+			onSub(notice)
+		}
+	case UserNoticeTypeResub:
+		if onResub != nil {
+			onResub(notice)
+		}
+	case UserNoticeTypeSubGift, UserNoticeTypeAnonSubGift, UserNoticeTypeSubMysteryGift:
+		if onSubGift != nil {
+			onSubGift(notice)
+		}
+	case UserNoticeTypeRaid:
+		if onRaid != nil {
+			onRaid(notice)
+		}
+	}
+}
+
+func (c *ChatBotClient) handleJoin(channel, user string) {
+	c.mu.RLock()
+	fn := c.onJoin
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(channel, user)
+	}
+}
+
+func (c *ChatBotClient) handlePart(channel, user string) {
+	c.mu.RLock()
+	fn := c.onPart
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(channel, user)
+	}
+}
+
+func (c *ChatBotClient) handleRoomState(state *RoomState) {
+	c.mu.RLock()
+	fn := c.onRoomState
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(state)
+	}
+}
+
+func (c *ChatBotClient) handleNotice(notice *Notice) {
+	c.mu.RLock()
+	fn := c.onNotice
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(notice)
+	}
+}
+
+func (c *ChatBotClient) handleClearChat(clear *ClearChat) {
+	c.mu.RLock()
+	fn := c.onClearChat
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(clear)
+	}
+}
+
+func (c *ChatBotClient) handleWhisper(whisper *Whisper) {
+	c.mu.RLock()
+	fn := c.onWhisper
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(whisper)
+	}
+}
+
+func (c *ChatBotClient) handleConnect() {
+	c.mu.RLock()
+	fn := c.onConnect
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn()
+	}
+}
+
+func (c *ChatBotClient) handleDisconnect() {
+	c.mu.RLock()
+	fn := c.onDisconnect
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn()
+	}
+}
+
+func (c *ChatBotClient) handleError(err error) {
+	c.mu.RLock()
+	fn := c.onError
+	c.mu.RUnlock()
+
+	if fn != nil {
+		fn(err)
+	}
+}

--- a/helix/irc.go
+++ b/helix/irc.go
@@ -1,0 +1,699 @@
+package helix
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// TwitchIRCWebSocket is the WebSocket URL for Twitch IRC.
+	TwitchIRCWebSocket = "wss://irc-ws.chat.twitch.tv:443"
+
+	// TwitchIRCTCP is the TCP address for Twitch IRC.
+	TwitchIRCTCP = "irc.chat.twitch.tv:6697"
+)
+
+// IRC command constants
+const (
+	ircCAP         = "CAP"
+	ircPASS        = "PASS"
+	ircNICK        = "NICK"
+	ircJOIN        = "JOIN"
+	ircPART        = "PART"
+	ircPRIVMSG     = "PRIVMSG"
+	ircWHISPER     = "WHISPER"
+	ircPING        = "PING"
+	ircPONG        = "PONG"
+	ircNOTICE      = "NOTICE"
+	ircUSERNOTICE  = "USERNOTICE"
+	ircROOMSTATE   = "ROOMSTATE"
+	ircCLEARCHAT   = "CLEARCHAT"
+	ircCLEARMSG    = "CLEARMSG"
+	ircGLOBALUSERSTATE = "GLOBALUSERSTATE"
+	ircUSERSTATE   = "USERSTATE"
+	ircRECONNECT   = "RECONNECT"
+)
+
+// IRC errors
+var (
+	ErrIRCNotConnected  = errors.New("irc: not connected")
+	ErrIRCAlreadyConnected = errors.New("irc: already connected")
+	ErrIRCAuthFailed    = errors.New("irc: authentication failed")
+)
+
+// IRCClient manages a connection to Twitch IRC.
+type IRCClient struct {
+	url   string
+	conn  *websocket.Conn
+	nick  string
+	token string
+
+	// Channel tracking
+	channels map[string]bool
+
+	// Handlers
+	onMessage         func(*ChatMessage)
+	onJoin            func(channel, user string)
+	onPart            func(channel, user string)
+	onNotice          func(*Notice)
+	onUserNotice      func(*UserNotice)
+	onRoomState       func(*RoomState)
+	onClearChat       func(*ClearChat)
+	onClearMessage    func(*ClearMessage)
+	onWhisper         func(*Whisper)
+	onGlobalUserState func(*GlobalUserState)
+	onUserState       func(*UserState)
+	onError           func(error)
+	onConnect         func()
+	onDisconnect      func()
+	onReconnect       func()
+	onRawMessage      func(string)
+
+	// State
+	mu           sync.RWMutex
+	connected    bool
+	stopChan     chan struct{}
+	writeMu      sync.Mutex
+	globalState  *GlobalUserState
+	pongReceived chan struct{}
+
+	// Options
+	autoReconnect  bool
+	reconnectDelay time.Duration
+	capabilities   []string
+}
+
+// IRCOption configures the IRC client.
+type IRCOption func(*IRCClient)
+
+// NewIRCClient creates a new IRC client.
+func NewIRCClient(nick, token string, opts ...IRCOption) *IRCClient {
+	// Ensure token has oauth: prefix
+	if !strings.HasPrefix(token, "oauth:") {
+		token = "oauth:" + token
+	}
+
+	c := &IRCClient{
+		url:            TwitchIRCWebSocket,
+		nick:           strings.ToLower(nick),
+		token:          token,
+		channels:       make(map[string]bool),
+		autoReconnect:  true,
+		reconnectDelay: 5 * time.Second,
+		capabilities: []string{
+			"twitch.tv/tags",
+			"twitch.tv/commands",
+			"twitch.tv/membership",
+		},
+		pongReceived: make(chan struct{}, 1),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// WithIRCURL sets a custom WebSocket URL.
+func WithIRCURL(url string) IRCOption {
+	return func(c *IRCClient) {
+		c.url = url
+	}
+}
+
+// WithAutoReconnect enables or disables auto-reconnect.
+func WithAutoReconnect(enabled bool) IRCOption {
+	return func(c *IRCClient) {
+		c.autoReconnect = enabled
+	}
+}
+
+// WithReconnectDelay sets the delay between reconnection attempts.
+func WithReconnectDelay(d time.Duration) IRCOption {
+	return func(c *IRCClient) {
+		c.reconnectDelay = d
+	}
+}
+
+// WithMessageHandler sets the handler for chat messages.
+func WithMessageHandler(fn func(*ChatMessage)) IRCOption {
+	return func(c *IRCClient) {
+		c.onMessage = fn
+	}
+}
+
+// WithJoinHandler sets the handler for join events.
+func WithJoinHandler(fn func(channel, user string)) IRCOption {
+	return func(c *IRCClient) {
+		c.onJoin = fn
+	}
+}
+
+// WithPartHandler sets the handler for part events.
+func WithPartHandler(fn func(channel, user string)) IRCOption {
+	return func(c *IRCClient) {
+		c.onPart = fn
+	}
+}
+
+// WithNoticeHandler sets the handler for notice messages.
+func WithNoticeHandler(fn func(*Notice)) IRCOption {
+	return func(c *IRCClient) {
+		c.onNotice = fn
+	}
+}
+
+// WithUserNoticeHandler sets the handler for user notices (subs, raids, etc.).
+func WithUserNoticeHandler(fn func(*UserNotice)) IRCOption {
+	return func(c *IRCClient) {
+		c.onUserNotice = fn
+	}
+}
+
+// WithRoomStateHandler sets the handler for room state changes.
+func WithRoomStateHandler(fn func(*RoomState)) IRCOption {
+	return func(c *IRCClient) {
+		c.onRoomState = fn
+	}
+}
+
+// WithClearChatHandler sets the handler for clear chat events.
+func WithClearChatHandler(fn func(*ClearChat)) IRCOption {
+	return func(c *IRCClient) {
+		c.onClearChat = fn
+	}
+}
+
+// WithClearMessageHandler sets the handler for clear message events.
+func WithClearMessageHandler(fn func(*ClearMessage)) IRCOption {
+	return func(c *IRCClient) {
+		c.onClearMessage = fn
+	}
+}
+
+// WithWhisperHandler sets the handler for whisper messages.
+func WithWhisperHandler(fn func(*Whisper)) IRCOption {
+	return func(c *IRCClient) {
+		c.onWhisper = fn
+	}
+}
+
+// WithGlobalUserStateHandler sets the handler for global user state.
+func WithGlobalUserStateHandler(fn func(*GlobalUserState)) IRCOption {
+	return func(c *IRCClient) {
+		c.onGlobalUserState = fn
+	}
+}
+
+// WithUserStateHandler sets the handler for user state.
+func WithUserStateHandler(fn func(*UserState)) IRCOption {
+	return func(c *IRCClient) {
+		c.onUserState = fn
+	}
+}
+
+// WithIRCErrorHandler sets the handler for errors.
+func WithIRCErrorHandler(fn func(error)) IRCOption {
+	return func(c *IRCClient) {
+		c.onError = fn
+	}
+}
+
+// WithConnectHandler sets the handler for successful connections.
+func WithConnectHandler(fn func()) IRCOption {
+	return func(c *IRCClient) {
+		c.onConnect = fn
+	}
+}
+
+// WithDisconnectHandler sets the handler for disconnections.
+func WithDisconnectHandler(fn func()) IRCOption {
+	return func(c *IRCClient) {
+		c.onDisconnect = fn
+	}
+}
+
+// WithReconnectHandler sets the handler for reconnection events.
+func WithReconnectHandler(fn func()) IRCOption {
+	return func(c *IRCClient) {
+		c.onReconnect = fn
+	}
+}
+
+// WithRawMessageHandler sets the handler for raw IRC messages.
+func WithRawMessageHandler(fn func(string)) IRCOption {
+	return func(c *IRCClient) {
+		c.onRawMessage = fn
+	}
+}
+
+// Connect establishes a connection to Twitch IRC.
+func (c *IRCClient) Connect(ctx context.Context) error {
+	c.mu.Lock()
+	if c.connected {
+		c.mu.Unlock()
+		return ErrIRCAlreadyConnected
+	}
+	c.mu.Unlock()
+
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, c.url, nil)
+	if err != nil {
+		return fmt.Errorf("connecting to IRC: %w", err)
+	}
+
+	c.mu.Lock()
+	c.conn = conn
+	c.stopChan = make(chan struct{})
+	c.mu.Unlock()
+
+	// Request capabilities
+	caps := strings.Join(c.capabilities, " ")
+	if err := c.send(fmt.Sprintf("CAP REQ :%s", caps)); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("requesting capabilities: %w", err)
+	}
+
+	// Authenticate
+	if err := c.send(fmt.Sprintf("PASS %s", c.token)); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("sending PASS: %w", err)
+	}
+
+	if err := c.send(fmt.Sprintf("NICK %s", c.nick)); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("sending NICK: %w", err)
+	}
+
+	// Wait for authentication response
+	if err := c.waitForAuth(ctx); err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	c.mu.Lock()
+	c.connected = true
+	c.mu.Unlock()
+
+	// Start read loop
+	go c.readLoop()
+
+	// Rejoin channels
+	c.mu.RLock()
+	channels := make([]string, 0, len(c.channels))
+	for ch := range c.channels {
+		channels = append(channels, ch)
+	}
+	c.mu.RUnlock()
+
+	if len(channels) > 0 {
+		_ = c.Join(channels...)
+	}
+
+	if c.onConnect != nil {
+		c.onConnect()
+	}
+
+	return nil
+}
+
+// waitForAuth waits for authentication confirmation.
+func (c *IRCClient) waitForAuth(ctx context.Context) error {
+	// Read messages until we get 001 (welcome) or NOTICE (auth failed)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("reading auth response: %w", err)
+		}
+
+		lines := strings.Split(string(data), "\r\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+
+			msg := parseIRCMessage(line)
+
+			switch msg.Command {
+			case "001": // RPL_WELCOME
+				return nil
+			case ircNOTICE:
+				if strings.Contains(msg.Trailing, "Login authentication failed") ||
+					strings.Contains(msg.Trailing, "Improperly formatted auth") {
+					return ErrIRCAuthFailed
+				}
+			case ircGLOBALUSERSTATE:
+				c.mu.Lock()
+				c.globalState = parseGlobalUserState(msg)
+				c.mu.Unlock()
+				if c.onGlobalUserState != nil {
+					c.onGlobalUserState(c.globalState)
+				}
+			case ircCAP:
+				// CAP ACK - capabilities acknowledged
+				continue
+			}
+		}
+	}
+}
+
+// readLoop continuously reads messages from the WebSocket.
+func (c *IRCClient) readLoop() {
+	defer func() {
+		c.mu.Lock()
+		wasConnected := c.connected
+		c.connected = false
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
+		c.mu.Unlock()
+
+		if wasConnected && c.onDisconnect != nil {
+			c.onDisconnect()
+		}
+
+		// Auto-reconnect
+		if wasConnected && c.autoReconnect {
+			go c.reconnect()
+		}
+	}()
+
+	reader := bufio.NewReader(nil)
+
+	for {
+		select {
+		case <-c.stopChan:
+			return
+		default:
+		}
+
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			if c.onError != nil && !errors.Is(err, websocket.ErrCloseSent) {
+				c.onError(fmt.Errorf("reading message: %w", err))
+			}
+			return
+		}
+
+		reader.Reset(strings.NewReader(string(data)))
+
+		lines := strings.Split(string(data), "\r\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+
+			if c.onRawMessage != nil {
+				c.onRawMessage(line)
+			}
+
+			c.handleMessage(line)
+		}
+	}
+}
+
+// handleMessage processes a single IRC message.
+func (c *IRCClient) handleMessage(raw string) {
+	msg := parseIRCMessage(raw)
+
+	switch msg.Command {
+	case ircPING:
+		_ = c.send("PONG :" + msg.Trailing)
+
+	case ircPONG:
+		select {
+		case c.pongReceived <- struct{}{}:
+		default:
+		}
+
+	case ircPRIVMSG:
+		if c.onMessage != nil {
+			c.onMessage(parseChatMessage(msg))
+		}
+
+	case ircWHISPER:
+		if c.onWhisper != nil {
+			c.onWhisper(parseWhisper(msg))
+		}
+
+	case ircUSERNOTICE:
+		if c.onUserNotice != nil {
+			c.onUserNotice(parseUserNotice(msg))
+		}
+
+	case ircNOTICE:
+		if c.onNotice != nil {
+			c.onNotice(parseNotice(msg))
+		}
+
+	case ircROOMSTATE:
+		if c.onRoomState != nil {
+			c.onRoomState(parseRoomState(msg))
+		}
+
+	case ircCLEARCHAT:
+		if c.onClearChat != nil {
+			c.onClearChat(parseClearChat(msg))
+		}
+
+	case ircCLEARMSG:
+		if c.onClearMessage != nil {
+			c.onClearMessage(parseClearMessage(msg))
+		}
+
+	case ircGLOBALUSERSTATE:
+		state := parseGlobalUserState(msg)
+		c.mu.Lock()
+		c.globalState = state
+		c.mu.Unlock()
+		if c.onGlobalUserState != nil {
+			c.onGlobalUserState(state)
+		}
+
+	case ircUSERSTATE:
+		if c.onUserState != nil {
+			c.onUserState(parseUserState(msg))
+		}
+
+	case ircJOIN:
+		if c.onJoin != nil {
+			channel := ""
+			if len(msg.Params) > 0 {
+				channel = parseChannel(msg.Params[0])
+			}
+			user := parseUserFromPrefix(msg.Prefix)
+			c.onJoin(channel, user)
+		}
+
+	case ircPART:
+		if c.onPart != nil {
+			channel := ""
+			if len(msg.Params) > 0 {
+				channel = parseChannel(msg.Params[0])
+			}
+			user := parseUserFromPrefix(msg.Prefix)
+			c.onPart(channel, user)
+		}
+
+	case ircRECONNECT:
+		// Twitch is requesting we reconnect
+		c.mu.Lock()
+		c.connected = false
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
+		c.mu.Unlock()
+		// readLoop will handle reconnection
+	}
+}
+
+// reconnect attempts to reconnect to IRC.
+func (c *IRCClient) reconnect() {
+	for {
+		c.mu.RLock()
+		stopChan := c.stopChan
+		c.mu.RUnlock()
+
+		select {
+		case <-stopChan:
+			return
+		case <-time.After(c.reconnectDelay):
+		}
+
+		if c.onReconnect != nil {
+			c.onReconnect()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		err := c.Connect(ctx)
+		cancel()
+
+		if err == nil {
+			return
+		}
+
+		if c.onError != nil {
+			c.onError(fmt.Errorf("reconnect failed: %w", err))
+		}
+	}
+}
+
+// send sends a raw IRC message.
+func (c *IRCClient) send(message string) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+
+	if conn == nil {
+		return ErrIRCNotConnected
+	}
+
+	return conn.WriteMessage(websocket.TextMessage, []byte(message+"\r\n"))
+}
+
+// Close closes the IRC connection.
+func (c *IRCClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.connected {
+		return nil
+	}
+
+	c.autoReconnect = false
+	c.connected = false
+
+	if c.stopChan != nil {
+		close(c.stopChan)
+	}
+
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+
+	return nil
+}
+
+// IsConnected returns whether the client is connected.
+func (c *IRCClient) IsConnected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.connected
+}
+
+// Join joins one or more channels.
+func (c *IRCClient) Join(channels ...string) error {
+	c.mu.Lock()
+	for _, ch := range channels {
+		c.channels[strings.ToLower(strings.TrimPrefix(ch, "#"))] = true
+	}
+	c.mu.Unlock()
+
+	if !c.IsConnected() {
+		return nil // Will join on connect
+	}
+
+	for _, ch := range channels {
+		ch = strings.ToLower(strings.TrimPrefix(ch, "#"))
+		if err := c.send(fmt.Sprintf("JOIN #%s", ch)); err != nil {
+			return fmt.Errorf("joining %s: %w", ch, err)
+		}
+	}
+
+	return nil
+}
+
+// Part leaves one or more channels.
+func (c *IRCClient) Part(channels ...string) error {
+	c.mu.Lock()
+	for _, ch := range channels {
+		delete(c.channels, strings.ToLower(strings.TrimPrefix(ch, "#")))
+	}
+	c.mu.Unlock()
+
+	if !c.IsConnected() {
+		return nil
+	}
+
+	for _, ch := range channels {
+		ch = strings.ToLower(strings.TrimPrefix(ch, "#"))
+		if err := c.send(fmt.Sprintf("PART #%s", ch)); err != nil {
+			return fmt.Errorf("parting %s: %w", ch, err)
+		}
+	}
+
+	return nil
+}
+
+// Say sends a message to a channel.
+func (c *IRCClient) Say(channel, message string) error {
+	channel = strings.ToLower(strings.TrimPrefix(channel, "#"))
+	return c.send(fmt.Sprintf("PRIVMSG #%s :%s", channel, message))
+}
+
+// Reply sends a reply to a message.
+func (c *IRCClient) Reply(channel, parentMsgID, message string) error {
+	channel = strings.ToLower(strings.TrimPrefix(channel, "#"))
+	return c.send(fmt.Sprintf("@reply-parent-msg-id=%s PRIVMSG #%s :%s", parentMsgID, channel, message))
+}
+
+// Whisper sends a whisper to a user.
+// Note: Whispers require verified bot status for high volume.
+func (c *IRCClient) Whisper(user, message string) error {
+	return c.send(fmt.Sprintf("PRIVMSG #jtv :/w %s %s", user, message))
+}
+
+// GetGlobalUserState returns the global user state.
+func (c *IRCClient) GetGlobalUserState() *GlobalUserState {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.globalState
+}
+
+// GetJoinedChannels returns the list of joined channels.
+func (c *IRCClient) GetJoinedChannels() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	channels := make([]string, 0, len(c.channels))
+	for ch := range c.channels {
+		channels = append(channels, ch)
+	}
+	return channels
+}
+
+// Ping sends a PING and waits for PONG.
+func (c *IRCClient) Ping(ctx context.Context) error {
+	// Clear any pending pong
+	select {
+	case <-c.pongReceived:
+	default:
+	}
+
+	if err := c.send("PING :tmi.twitch.tv"); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.pongReceived:
+		return nil
+	}
+}

--- a/helix/irc_parser.go
+++ b/helix/irc_parser.go
@@ -1,0 +1,477 @@
+package helix
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseIRCMessage parses a raw IRC message into an IRCMessage struct.
+// Format: [@tags] [:prefix] COMMAND [params...] [:trailing]
+func parseIRCMessage(raw string) *IRCMessage {
+	msg := &IRCMessage{
+		Raw:  raw,
+		Tags: make(map[string]string),
+	}
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return msg
+	}
+
+	pos := 0
+
+	// Parse tags (starts with @)
+	if raw[pos] == '@' {
+		end := strings.Index(raw, " ")
+		if end == -1 {
+			return msg
+		}
+		msg.Tags = parseTags(raw[1:end])
+		pos = end + 1
+	}
+
+	// Skip whitespace
+	for pos < len(raw) && raw[pos] == ' ' {
+		pos++
+	}
+
+	// Parse prefix (starts with :)
+	if pos < len(raw) && raw[pos] == ':' {
+		end := strings.Index(raw[pos:], " ")
+		if end == -1 {
+			msg.Prefix = raw[pos+1:]
+			return msg
+		}
+		msg.Prefix = raw[pos+1 : pos+end]
+		pos = pos + end + 1
+	}
+
+	// Skip whitespace
+	for pos < len(raw) && raw[pos] == ' ' {
+		pos++
+	}
+
+	// Parse command
+	end := strings.Index(raw[pos:], " ")
+	if end == -1 {
+		msg.Command = raw[pos:]
+		return msg
+	}
+	msg.Command = raw[pos : pos+end]
+	pos = pos + end + 1
+
+	// Skip whitespace
+	for pos < len(raw) && raw[pos] == ' ' {
+		pos++
+	}
+
+	// Parse params
+	for pos < len(raw) {
+		if raw[pos] == ':' {
+			// Trailing parameter (rest of message)
+			msg.Trailing = raw[pos+1:]
+			break
+		}
+
+		end := strings.Index(raw[pos:], " ")
+		if end == -1 {
+			msg.Params = append(msg.Params, raw[pos:])
+			break
+		}
+		msg.Params = append(msg.Params, raw[pos:pos+end])
+		pos = pos + end + 1
+
+		// Skip whitespace
+		for pos < len(raw) && raw[pos] == ' ' {
+			pos++
+		}
+	}
+
+	return msg
+}
+
+// parseTags parses IRCv3 tags from a tag string.
+func parseTags(tagStr string) map[string]string {
+	tags := make(map[string]string)
+	if tagStr == "" {
+		return tags
+	}
+
+	pairs := strings.Split(tagStr, ";")
+	for _, pair := range pairs {
+		if pair == "" {
+			continue
+		}
+		eqIdx := strings.Index(pair, "=")
+		if eqIdx == -1 {
+			tags[pair] = ""
+			continue
+		}
+		key := pair[:eqIdx]
+		value := unescapeTagValue(pair[eqIdx+1:])
+		tags[key] = value
+	}
+
+	return tags
+}
+
+// unescapeTagValue unescapes IRC tag values.
+func unescapeTagValue(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+
+	i := 0
+	for i < len(s) {
+		if i+1 < len(s) && s[i] == '\\' {
+			switch s[i+1] {
+			case ':':
+				result.WriteByte(';')
+			case 's':
+				result.WriteByte(' ')
+			case '\\':
+				result.WriteByte('\\')
+			case 'r':
+				result.WriteByte('\r')
+			case 'n':
+				result.WriteByte('\n')
+			default:
+				result.WriteByte(s[i+1])
+			}
+			i += 2
+		} else {
+			result.WriteByte(s[i])
+			i++
+		}
+	}
+
+	return result.String()
+}
+
+// parseEmotes parses the emotes tag into a slice of IRCEmote.
+// Format: emote_id:start-end,start-end/emote_id:start-end
+func parseEmotes(emoteStr string) []IRCEmote {
+	if emoteStr == "" {
+		return nil
+	}
+
+	var emotes []IRCEmote
+	emoteParts := strings.Split(emoteStr, "/")
+
+	for _, part := range emoteParts {
+		if part == "" {
+			continue
+		}
+
+		colonIdx := strings.Index(part, ":")
+		if colonIdx == -1 {
+			continue
+		}
+
+		emoteID := part[:colonIdx]
+		positionsStr := part[colonIdx+1:]
+		positions := strings.Split(positionsStr, ",")
+
+		for _, posStr := range positions {
+			dashIdx := strings.Index(posStr, "-")
+			if dashIdx == -1 {
+				continue
+			}
+
+			start, err1 := strconv.Atoi(posStr[:dashIdx])
+			end, err2 := strconv.Atoi(posStr[dashIdx+1:])
+			if err1 != nil || err2 != nil {
+				continue
+			}
+
+			emotes = append(emotes, IRCEmote{
+				ID:    emoteID,
+				Start: start,
+				End:   end,
+				Count: 1,
+			})
+		}
+	}
+
+	return emotes
+}
+
+// parseBadges parses the badges tag into a map.
+// Format: badge/version,badge/version
+func parseBadges(badgeStr string) map[string]string {
+	badges := make(map[string]string)
+	if badgeStr == "" {
+		return badges
+	}
+
+	parts := strings.Split(badgeStr, ",")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		slashIdx := strings.Index(part, "/")
+		if slashIdx == -1 {
+			badges[part] = ""
+			continue
+		}
+		badges[part[:slashIdx]] = part[slashIdx+1:]
+	}
+
+	return badges
+}
+
+// parseTimestamp parses the tmi-sent-ts tag into a time.Time.
+func parseTimestamp(ts string) time.Time {
+	if ts == "" {
+		return time.Now()
+	}
+	ms, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return time.Now()
+	}
+	return time.UnixMilli(ms)
+}
+
+// parseBool parses a "0" or "1" string into a bool.
+func parseBool(s string) bool {
+	return s == "1"
+}
+
+// parseInt parses a string into an int, returning 0 on error.
+func parseInt(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// parseChannel removes the # prefix from a channel name.
+func parseChannel(s string) string {
+	return strings.TrimPrefix(s, "#")
+}
+
+// parseUserFromPrefix extracts the username from a prefix.
+// Format: nick!user@host
+func parseUserFromPrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	bangIdx := strings.Index(prefix, "!")
+	if bangIdx == -1 {
+		return prefix
+	}
+	return prefix[:bangIdx]
+}
+
+// parseChatMessage converts an IRCMessage into a ChatMessage.
+func parseChatMessage(msg *IRCMessage) *ChatMessage {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	badges := parseBadges(msg.Tags["badges"])
+
+	return &ChatMessage{
+		ID:            msg.Tags["id"],
+		Channel:       channel,
+		User:          msg.Tags["login"],
+		UserID:        msg.Tags["user-id"],
+		Message:       msg.Trailing,
+		Emotes:        parseEmotes(msg.Tags["emotes"]),
+		Badges:        badges,
+		BadgeInfo:     parseBadges(msg.Tags["badge-info"]),
+		Color:         msg.Tags["color"],
+		DisplayName:   msg.Tags["display-name"],
+		IsMod:         parseBool(msg.Tags["mod"]),
+		IsVIP:         badges["vip"] != "",
+		IsSubscriber:  parseBool(msg.Tags["subscriber"]),
+		IsBroadcaster: badges["broadcaster"] != "",
+		Bits:          parseInt(msg.Tags["bits"]),
+		FirstMessage:  parseBool(msg.Tags["first-msg"]),
+		ReturningChatter: parseBool(msg.Tags["returning-chatter"]),
+		ReplyParentMsgID:       msg.Tags["reply-parent-msg-id"],
+		ReplyParentUserID:      msg.Tags["reply-parent-user-id"],
+		ReplyParentUserLogin:   msg.Tags["reply-parent-user-login"],
+		ReplyParentDisplayName: msg.Tags["reply-parent-display-name"],
+		ReplyParentMsgBody:     msg.Tags["reply-parent-msg-body"],
+		Timestamp:     parseTimestamp(msg.Tags["tmi-sent-ts"]),
+		Raw:           msg.Raw,
+	}
+}
+
+// parseUserNotice converts an IRCMessage into a UserNotice.
+func parseUserNotice(msg *IRCMessage) *UserNotice {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	// Extract msg-param-* tags
+	msgParams := make(map[string]string)
+	for key, value := range msg.Tags {
+		if strings.HasPrefix(key, "msg-param-") {
+			paramName := strings.TrimPrefix(key, "msg-param-")
+			msgParams[paramName] = value
+		}
+	}
+
+	return &UserNotice{
+		Type:          msg.Tags["msg-id"],
+		Channel:       channel,
+		User:          msg.Tags["login"],
+		UserID:        msg.Tags["user-id"],
+		DisplayName:   msg.Tags["display-name"],
+		Message:       msg.Trailing,
+		SystemMessage: msg.Tags["system-msg"],
+		MsgParams:     msgParams,
+		Badges:        parseBadges(msg.Tags["badges"]),
+		BadgeInfo:     parseBadges(msg.Tags["badge-info"]),
+		Color:         msg.Tags["color"],
+		Emotes:        parseEmotes(msg.Tags["emotes"]),
+		Timestamp:     parseTimestamp(msg.Tags["tmi-sent-ts"]),
+		Raw:           msg.Raw,
+	}
+}
+
+// parseRoomState converts an IRCMessage into a RoomState.
+func parseRoomState(msg *IRCMessage) *RoomState {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	followersOnly := -1
+	if fo, ok := msg.Tags["followers-only"]; ok {
+		followersOnly = parseInt(fo)
+	}
+
+	return &RoomState{
+		Channel:       channel,
+		EmoteOnly:     parseBool(msg.Tags["emote-only"]),
+		FollowersOnly: followersOnly,
+		R9K:           parseBool(msg.Tags["r9k"]),
+		Slow:          parseInt(msg.Tags["slow"]),
+		SubsOnly:      parseBool(msg.Tags["subs-only"]),
+		RoomID:        msg.Tags["room-id"],
+		Raw:           msg.Raw,
+	}
+}
+
+// parseNotice converts an IRCMessage into a Notice.
+func parseNotice(msg *IRCMessage) *Notice {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	return &Notice{
+		Channel: channel,
+		Message: msg.Trailing,
+		MsgID:   msg.Tags["msg-id"],
+		Raw:     msg.Raw,
+	}
+}
+
+// parseClearChat converts an IRCMessage into a ClearChat.
+func parseClearChat(msg *IRCMessage) *ClearChat {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	return &ClearChat{
+		Channel:      channel,
+		User:         msg.Trailing,
+		BanDuration:  parseInt(msg.Tags["ban-duration"]),
+		RoomID:       msg.Tags["room-id"],
+		TargetUserID: msg.Tags["target-user-id"],
+		Timestamp:    parseTimestamp(msg.Tags["tmi-sent-ts"]),
+		Raw:          msg.Raw,
+	}
+}
+
+// parseClearMessage converts an IRCMessage into a ClearMessage.
+func parseClearMessage(msg *IRCMessage) *ClearMessage {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	return &ClearMessage{
+		Channel:     channel,
+		User:        msg.Tags["login"],
+		Message:     msg.Trailing,
+		TargetMsgID: msg.Tags["target-msg-id"],
+		Timestamp:   parseTimestamp(msg.Tags["tmi-sent-ts"]),
+		Raw:         msg.Raw,
+	}
+}
+
+// parseWhisper converts an IRCMessage into a Whisper.
+func parseWhisper(msg *IRCMessage) *Whisper {
+	to := ""
+	if len(msg.Params) > 0 {
+		to = msg.Params[0]
+	}
+
+	return &Whisper{
+		From:        parseUserFromPrefix(msg.Prefix),
+		FromID:      msg.Tags["user-id"],
+		To:          to,
+		Message:     msg.Trailing,
+		DisplayName: msg.Tags["display-name"],
+		Color:       msg.Tags["color"],
+		Badges:      parseBadges(msg.Tags["badges"]),
+		Emotes:      parseEmotes(msg.Tags["emotes"]),
+		MessageID:   msg.Tags["message-id"],
+		ThreadID:    msg.Tags["thread-id"],
+		Raw:         msg.Raw,
+	}
+}
+
+// parseGlobalUserState converts an IRCMessage into a GlobalUserState.
+func parseGlobalUserState(msg *IRCMessage) *GlobalUserState {
+	emoteSets := []string{}
+	if es := msg.Tags["emote-sets"]; es != "" {
+		emoteSets = strings.Split(es, ",")
+	}
+
+	return &GlobalUserState{
+		UserID:      msg.Tags["user-id"],
+		DisplayName: msg.Tags["display-name"],
+		Color:       msg.Tags["color"],
+		Badges:      parseBadges(msg.Tags["badges"]),
+		BadgeInfo:   parseBadges(msg.Tags["badge-info"]),
+		EmoteSets:   emoteSets,
+		Raw:         msg.Raw,
+	}
+}
+
+// parseUserState converts an IRCMessage into a UserState.
+func parseUserState(msg *IRCMessage) *UserState {
+	channel := ""
+	if len(msg.Params) > 0 {
+		channel = parseChannel(msg.Params[0])
+	}
+
+	emoteSets := []string{}
+	if es := msg.Tags["emote-sets"]; es != "" {
+		emoteSets = strings.Split(es, ",")
+	}
+
+	badges := parseBadges(msg.Tags["badges"])
+
+	return &UserState{
+		Channel:      channel,
+		DisplayName:  msg.Tags["display-name"],
+		Color:        msg.Tags["color"],
+		Badges:       badges,
+		BadgeInfo:    parseBadges(msg.Tags["badge-info"]),
+		EmoteSets:    emoteSets,
+		IsMod:        parseBool(msg.Tags["mod"]),
+		IsSubscriber: parseBool(msg.Tags["subscriber"]),
+		Raw:          msg.Raw,
+	}
+}

--- a/helix/irc_test.go
+++ b/helix/irc_test.go
@@ -1,0 +1,552 @@
+package helix
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseIRCMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected *IRCMessage
+	}{
+		{
+			name: "simple command",
+			raw:  "PING :tmi.twitch.tv",
+			expected: &IRCMessage{
+				Raw:      "PING :tmi.twitch.tv",
+				Tags:     map[string]string{},
+				Command:  "PING",
+				Trailing: "tmi.twitch.tv",
+			},
+		},
+		{
+			name: "privmsg with tags",
+			raw:  "@badge-info=;badges=broadcaster/1;color=#FF0000;display-name=TestUser;emotes=;id=abc123;mod=0;room-id=12345;subscriber=0;tmi-sent-ts=1234567890123;turbo=0;user-id=12345;user-type= :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Hello World",
+			expected: &IRCMessage{
+				Raw: "@badge-info=;badges=broadcaster/1;color=#FF0000;display-name=TestUser;emotes=;id=abc123;mod=0;room-id=12345;subscriber=0;tmi-sent-ts=1234567890123;turbo=0;user-id=12345;user-type= :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Hello World",
+				Tags: map[string]string{
+					"badge-info":   "",
+					"badges":       "broadcaster/1",
+					"color":        "#FF0000",
+					"display-name": "TestUser",
+					"emotes":       "",
+					"id":           "abc123",
+					"mod":          "0",
+					"room-id":      "12345",
+					"subscriber":   "0",
+					"tmi-sent-ts":  "1234567890123",
+					"turbo":        "0",
+					"user-id":      "12345",
+					"user-type":    "",
+				},
+				Prefix:   "testuser!testuser@testuser.tmi.twitch.tv",
+				Command:  "PRIVMSG",
+				Params:   []string{"#testchannel"},
+				Trailing: "Hello World",
+			},
+		},
+		{
+			name: "join message",
+			raw:  ":testuser!testuser@testuser.tmi.twitch.tv JOIN #testchannel",
+			expected: &IRCMessage{
+				Raw:     ":testuser!testuser@testuser.tmi.twitch.tv JOIN #testchannel",
+				Tags:    map[string]string{},
+				Prefix:  "testuser!testuser@testuser.tmi.twitch.tv",
+				Command: "JOIN",
+				Params:  []string{"#testchannel"},
+			},
+		},
+		{
+			name: "cap ack",
+			raw:  ":tmi.twitch.tv CAP * ACK :twitch.tv/tags twitch.tv/commands",
+			expected: &IRCMessage{
+				Raw:      ":tmi.twitch.tv CAP * ACK :twitch.tv/tags twitch.tv/commands",
+				Tags:     map[string]string{},
+				Prefix:   "tmi.twitch.tv",
+				Command:  "CAP",
+				Params:   []string{"*", "ACK"},
+				Trailing: "twitch.tv/tags twitch.tv/commands",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseIRCMessage(tt.raw)
+
+			if result.Raw != tt.expected.Raw {
+				t.Errorf("Raw mismatch: got %q, want %q", result.Raw, tt.expected.Raw)
+			}
+
+			if result.Command != tt.expected.Command {
+				t.Errorf("Command mismatch: got %q, want %q", result.Command, tt.expected.Command)
+			}
+
+			if result.Prefix != tt.expected.Prefix {
+				t.Errorf("Prefix mismatch: got %q, want %q", result.Prefix, tt.expected.Prefix)
+			}
+
+			if result.Trailing != tt.expected.Trailing {
+				t.Errorf("Trailing mismatch: got %q, want %q", result.Trailing, tt.expected.Trailing)
+			}
+
+			if len(result.Params) != len(tt.expected.Params) {
+				t.Errorf("Params length mismatch: got %d, want %d", len(result.Params), len(tt.expected.Params))
+			} else {
+				for i, p := range result.Params {
+					if p != tt.expected.Params[i] {
+						t.Errorf("Params[%d] mismatch: got %q, want %q", i, p, tt.expected.Params[i])
+					}
+				}
+			}
+
+			for k, v := range tt.expected.Tags {
+				if result.Tags[k] != v {
+					t.Errorf("Tag %q mismatch: got %q, want %q", k, result.Tags[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:  "basic tags",
+			input: "color=#FF0000;display-name=TestUser",
+			expected: map[string]string{
+				"color":        "#FF0000",
+				"display-name": "TestUser",
+			},
+		},
+		{
+			name:  "empty value",
+			input: "badge-info=;badges=broadcaster/1",
+			expected: map[string]string{
+				"badge-info": "",
+				"badges":     "broadcaster/1",
+			},
+		},
+		{
+			name:  "escaped values",
+			input: `msg=hello\sworld\:\)`,
+			expected: map[string]string{
+				"msg": "hello world;)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseTags(tt.input)
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("Tag %q: got %q, want %q", k, result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEmotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []IRCEmote
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:  "single emote",
+			input: "25:0-4",
+			expected: []IRCEmote{
+				{ID: "25", Start: 0, End: 4, Count: 1},
+			},
+		},
+		{
+			name:  "multiple positions",
+			input: "25:0-4,6-10",
+			expected: []IRCEmote{
+				{ID: "25", Start: 0, End: 4, Count: 1},
+				{ID: "25", Start: 6, End: 10, Count: 1},
+			},
+		},
+		{
+			name:  "multiple emotes",
+			input: "25:0-4/1902:6-10",
+			expected: []IRCEmote{
+				{ID: "25", Start: 0, End: 4, Count: 1},
+				{ID: "1902", Start: 6, End: 10, Count: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseEmotes(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Fatalf("Length mismatch: got %d, want %d", len(result), len(tt.expected))
+			}
+
+			for i, e := range result {
+				if e.ID != tt.expected[i].ID {
+					t.Errorf("Emote[%d].ID: got %q, want %q", i, e.ID, tt.expected[i].ID)
+				}
+				if e.Start != tt.expected[i].Start {
+					t.Errorf("Emote[%d].Start: got %d, want %d", i, e.Start, tt.expected[i].Start)
+				}
+				if e.End != tt.expected[i].End {
+					t.Errorf("Emote[%d].End: got %d, want %d", i, e.End, tt.expected[i].End)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBadges(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:  "single badge",
+			input: "broadcaster/1",
+			expected: map[string]string{
+				"broadcaster": "1",
+			},
+		},
+		{
+			name:  "multiple badges",
+			input: "broadcaster/1,subscriber/12,premium/1",
+			expected: map[string]string{
+				"broadcaster": "1",
+				"subscriber":  "12",
+				"premium":     "1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseBadges(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Fatalf("Length mismatch: got %d, want %d", len(result), len(tt.expected))
+			}
+
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("Badge %q: got %q, want %q", k, result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseChatMessage(t *testing.T) {
+	raw := "@badge-info=subscriber/12;badges=subscriber/12,premium/1;color=#FF0000;display-name=TestUser;emotes=25:0-4;first-msg=0;id=abc123-def456;mod=1;room-id=12345;subscriber=1;tmi-sent-ts=1234567890123;turbo=0;user-id=67890;user-type=mod :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :Kappa Hello!"
+
+	msg := parseIRCMessage(raw)
+	chat := parseChatMessage(msg)
+
+	if chat.ID != "abc123-def456" {
+		t.Errorf("ID: got %q, want %q", chat.ID, "abc123-def456")
+	}
+
+	if chat.Channel != "testchannel" {
+		t.Errorf("Channel: got %q, want %q", chat.Channel, "testchannel")
+	}
+
+	if chat.UserID != "67890" {
+		t.Errorf("UserID: got %q, want %q", chat.UserID, "67890")
+	}
+
+	if chat.DisplayName != "TestUser" {
+		t.Errorf("DisplayName: got %q, want %q", chat.DisplayName, "TestUser")
+	}
+
+	if chat.Message != "Kappa Hello!" {
+		t.Errorf("Message: got %q, want %q", chat.Message, "Kappa Hello!")
+	}
+
+	if chat.Color != "#FF0000" {
+		t.Errorf("Color: got %q, want %q", chat.Color, "#FF0000")
+	}
+
+	if !chat.IsMod {
+		t.Error("IsMod should be true")
+	}
+
+	if !chat.IsSubscriber {
+		t.Error("IsSubscriber should be true")
+	}
+
+	if len(chat.Emotes) != 1 {
+		t.Fatalf("Expected 1 emote, got %d", len(chat.Emotes))
+	}
+
+	if chat.Emotes[0].ID != "25" {
+		t.Errorf("Emote ID: got %q, want %q", chat.Emotes[0].ID, "25")
+	}
+
+	if chat.Badges["subscriber"] != "12" {
+		t.Errorf("Subscriber badge: got %q, want %q", chat.Badges["subscriber"], "12")
+	}
+}
+
+func TestParseUserNotice(t *testing.T) {
+	raw := "@badge-info=subscriber/1;badges=subscriber/0;color=#FF0000;display-name=TestGifter;emotes=;id=abc123;login=testgifter;mod=0;msg-id=subgift;msg-param-gift-months=1;msg-param-months=1;msg-param-recipient-display-name=TestRecipient;msg-param-recipient-id=12345;msg-param-recipient-user-name=testrecipient;msg-param-sub-plan-name=Channel\\sSubscription;msg-param-sub-plan=1000;room-id=67890;subscriber=1;system-msg=TestGifter\\sgifted\\sa\\sTier\\s1\\ssub\\sto\\sTestRecipient!;tmi-sent-ts=1234567890123;user-id=11111;user-type= :tmi.twitch.tv USERNOTICE #testchannel"
+
+	msg := parseIRCMessage(raw)
+	notice := parseUserNotice(msg)
+
+	if notice.Type != "subgift" {
+		t.Errorf("Type: got %q, want %q", notice.Type, "subgift")
+	}
+
+	if notice.Channel != "testchannel" {
+		t.Errorf("Channel: got %q, want %q", notice.Channel, "testchannel")
+	}
+
+	if notice.User != "testgifter" {
+		t.Errorf("User: got %q, want %q", notice.User, "testgifter")
+	}
+
+	if notice.MsgParams["sub-plan"] != "1000" {
+		t.Errorf("sub-plan: got %q, want %q", notice.MsgParams["sub-plan"], "1000")
+	}
+
+	if notice.MsgParams["recipient-user-name"] != "testrecipient" {
+		t.Errorf("recipient-user-name: got %q, want %q", notice.MsgParams["recipient-user-name"], "testrecipient")
+	}
+}
+
+func TestParseRoomState(t *testing.T) {
+	raw := "@emote-only=0;followers-only=10;r9k=0;room-id=12345;slow=30;subs-only=1 :tmi.twitch.tv ROOMSTATE #testchannel"
+
+	msg := parseIRCMessage(raw)
+	state := parseRoomState(msg)
+
+	if state.Channel != "testchannel" {
+		t.Errorf("Channel: got %q, want %q", state.Channel, "testchannel")
+	}
+
+	if state.EmoteOnly {
+		t.Error("EmoteOnly should be false")
+	}
+
+	if state.FollowersOnly != 10 {
+		t.Errorf("FollowersOnly: got %d, want %d", state.FollowersOnly, 10)
+	}
+
+	if state.R9K {
+		t.Error("R9K should be false")
+	}
+
+	if state.Slow != 30 {
+		t.Errorf("Slow: got %d, want %d", state.Slow, 30)
+	}
+
+	if !state.SubsOnly {
+		t.Error("SubsOnly should be true")
+	}
+}
+
+func TestParseClearChat(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		expectedUser  string
+		expectedDuration int
+	}{
+		{
+			name:          "timeout",
+			raw:           "@ban-duration=600;room-id=12345;target-user-id=67890;tmi-sent-ts=1234567890123 :tmi.twitch.tv CLEARCHAT #testchannel :baduser",
+			expectedUser:  "baduser",
+			expectedDuration: 600,
+		},
+		{
+			name:          "ban",
+			raw:           "@room-id=12345;target-user-id=67890;tmi-sent-ts=1234567890123 :tmi.twitch.tv CLEARCHAT #testchannel :baduser",
+			expectedUser:  "baduser",
+			expectedDuration: 0,
+		},
+		{
+			name:          "clear chat",
+			raw:           "@room-id=12345;tmi-sent-ts=1234567890123 :tmi.twitch.tv CLEARCHAT #testchannel",
+			expectedUser:  "",
+			expectedDuration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := parseIRCMessage(tt.raw)
+			clear := parseClearChat(msg)
+
+			if clear.User != tt.expectedUser {
+				t.Errorf("User: got %q, want %q", clear.User, tt.expectedUser)
+			}
+
+			if clear.BanDuration != tt.expectedDuration {
+				t.Errorf("BanDuration: got %d, want %d", clear.BanDuration, tt.expectedDuration)
+			}
+		})
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	ts := parseTimestamp("1234567890123")
+	expected := time.UnixMilli(1234567890123)
+
+	if !ts.Equal(expected) {
+		t.Errorf("Timestamp: got %v, want %v", ts, expected)
+	}
+}
+
+func TestParseUserFromPrefix(t *testing.T) {
+	tests := []struct {
+		prefix   string
+		expected string
+	}{
+		{"testuser!testuser@testuser.tmi.twitch.tv", "testuser"},
+		{"testuser", "testuser"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := parseUserFromPrefix(tt.prefix)
+		if result != tt.expected {
+			t.Errorf("parseUserFromPrefix(%q): got %q, want %q", tt.prefix, result, tt.expected)
+		}
+	}
+}
+
+func TestNewIRCClient(t *testing.T) {
+	client := NewIRCClient("testuser", "token123")
+
+	if client.nick != "testuser" {
+		t.Errorf("nick: got %q, want %q", client.nick, "testuser")
+	}
+
+	if client.token != "oauth:token123" {
+		t.Errorf("token: got %q, want %q", client.token, "oauth:token123")
+	}
+
+	if client.url != TwitchIRCWebSocket {
+		t.Errorf("url: got %q, want %q", client.url, TwitchIRCWebSocket)
+	}
+
+	// Test with oauth: prefix already present
+	client2 := NewIRCClient("testuser", "oauth:token456")
+	if client2.token != "oauth:token456" {
+		t.Errorf("token with prefix: got %q, want %q", client2.token, "oauth:token456")
+	}
+}
+
+func TestIRCClientOptions(t *testing.T) {
+	messageReceived := false
+	errorReceived := false
+
+	client := NewIRCClient("testuser", "token",
+		WithIRCURL("wss://custom.url"),
+		WithAutoReconnect(false),
+		WithReconnectDelay(10*time.Second),
+		WithMessageHandler(func(m *ChatMessage) {
+			messageReceived = true
+		}),
+		WithIRCErrorHandler(func(err error) {
+			errorReceived = true
+		}),
+	)
+
+	if client.url != "wss://custom.url" {
+		t.Errorf("url: got %q, want %q", client.url, "wss://custom.url")
+	}
+
+	if client.autoReconnect {
+		t.Error("autoReconnect should be false")
+	}
+
+	if client.reconnectDelay != 10*time.Second {
+		t.Errorf("reconnectDelay: got %v, want %v", client.reconnectDelay, 10*time.Second)
+	}
+
+	// Test that handlers are set
+	if client.onMessage == nil {
+		t.Error("onMessage handler should be set")
+	}
+
+	if client.onError == nil {
+		t.Error("onError handler should be set")
+	}
+
+	// Call handlers to verify they work
+	client.onMessage(&ChatMessage{})
+	if !messageReceived {
+		t.Error("message handler was not called")
+	}
+
+	client.onError(nil)
+	if !errorReceived {
+		t.Error("error handler was not called")
+	}
+}
+
+func TestChannelManagement(t *testing.T) {
+	client := NewIRCClient("testuser", "token")
+
+	// Join channels while disconnected (should be queued)
+	err := client.Join("channel1", "#channel2", "CHANNEL3")
+	if err != nil {
+		t.Errorf("Join error: %v", err)
+	}
+
+	channels := client.GetJoinedChannels()
+	if len(channels) != 3 {
+		t.Errorf("Expected 3 channels, got %d", len(channels))
+	}
+
+	// Verify channel names are normalized
+	channelMap := make(map[string]bool)
+	for _, ch := range channels {
+		channelMap[ch] = true
+	}
+
+	if !channelMap["channel1"] {
+		t.Error("channel1 should be in joined channels")
+	}
+	if !channelMap["channel2"] {
+		t.Error("channel2 should be in joined channels")
+	}
+	if !channelMap["channel3"] {
+		t.Error("channel3 should be in joined channels")
+	}
+
+	// Part a channel
+	err = client.Part("channel1")
+	if err != nil {
+		t.Errorf("Part error: %v", err)
+	}
+
+	channels = client.GetJoinedChannels()
+	if len(channels) != 2 {
+		t.Errorf("Expected 2 channels after part, got %d", len(channels))
+	}
+}

--- a/helix/irc_types.go
+++ b/helix/irc_types.go
@@ -1,0 +1,211 @@
+package helix
+
+import "time"
+
+// ChatMessage represents a PRIVMSG from Twitch IRC.
+type ChatMessage struct {
+	ID            string            // Unique message ID
+	Channel       string            // Channel name (without #)
+	User          string            // Username (login)
+	UserID        string            // User's Twitch ID
+	Message       string            // Message content
+	Emotes        []IRCEmote        // Emotes used in the message
+	Badges        map[string]string // User badges (badge-name -> version)
+	BadgeInfo     map[string]string // Additional badge info (e.g., subscriber months)
+	Color         string            // User's chat color (#RRGGBB)
+	DisplayName   string            // User's display name
+	IsMod         bool              // Is channel moderator
+	IsVIP         bool              // Is VIP
+	IsSubscriber  bool              // Is subscriber
+	IsBroadcaster bool              // Is the channel broadcaster
+	Bits          int               // Bits cheered (0 if none)
+	FirstMessage  bool              // Is this user's first message in channel
+	ReturningChatter bool           // Is a returning chatter
+	ReplyParentMsgID   string       // Parent message ID if this is a reply
+	ReplyParentUserID  string       // Parent message user ID
+	ReplyParentUserLogin string     // Parent message username
+	ReplyParentDisplayName string   // Parent message display name
+	ReplyParentMsgBody string       // Parent message content
+	Timestamp     time.Time         // Server timestamp
+	Raw           string            // Raw IRC message
+}
+
+// IRCEmote represents an emote used in an IRC message.
+type IRCEmote struct {
+	ID     string // Emote ID
+	Name   string // Emote name/code
+	Start  int    // Start position in message
+	End    int    // End position in message
+	Count  int    // Number of times used
+}
+
+// UserNotice represents a USERNOTICE message (subs, raids, etc.).
+type UserNotice struct {
+	Type          string            // sub, resub, subgift, raid, ritual, etc.
+	Channel       string            // Channel name
+	User          string            // Username
+	UserID        string            // User's Twitch ID
+	DisplayName   string            // Display name
+	Message       string            // Optional user message
+	SystemMessage string            // System-generated message
+	MsgParams     map[string]string // Type-specific parameters
+	Badges        map[string]string // User badges
+	BadgeInfo     map[string]string // Badge info
+	Color         string            // User color
+	Emotes        []IRCEmote        // Emotes in message
+	Timestamp     time.Time         // Server timestamp
+	Raw           string            // Raw IRC message
+}
+
+// Common MsgParams keys for UserNotice:
+// - msg-param-cumulative-months: Total months subscribed
+// - msg-param-months: Months in current streak
+// - msg-param-multimonth-duration: Multi-month gift duration
+// - msg-param-multimonth-tenure: Tenure of multi-month
+// - msg-param-should-share-streak: Whether to share streak
+// - msg-param-streak-months: Streak months
+// - msg-param-sub-plan: Subscription plan (1000, 2000, 3000, Prime)
+// - msg-param-sub-plan-name: Plan display name
+// - msg-param-gift-months: Gifted months
+// - msg-param-recipient-id: Gift recipient ID
+// - msg-param-recipient-user-name: Gift recipient username
+// - msg-param-recipient-display-name: Gift recipient display name
+// - msg-param-sender-count: Sender's total gift count
+// - msg-param-viewerCount: Raid viewer count
+// - msg-param-displayName: Raid display name
+// - msg-param-login: Raid login
+
+// UserNotice types
+const (
+	UserNoticeTypeSub               = "sub"
+	UserNoticeTypeResub             = "resub"
+	UserNoticeTypeSubGift           = "subgift"
+	UserNoticeTypeAnonSubGift       = "anonsubgift"
+	UserNoticeTypeSubMysteryGift    = "submysterygift"
+	UserNoticeTypeGiftPaidUpgrade   = "giftpaidupgrade"
+	UserNoticeTypePrimePaidUpgrade  = "primepaidupgrade"
+	UserNoticeTypeRaid              = "raid"
+	UserNoticeTypeUnraid            = "unraid"
+	UserNoticeTypeRitual            = "ritual"
+	UserNoticeTypeBitsBadgeTier     = "bitsbadgetier"
+	UserNoticeTypeCommunityPayForward = "communitypayforward"
+	UserNoticeTypeStandardPayForward  = "standardpayforward"
+	UserNoticeTypeAnnouncement      = "announcement"
+)
+
+// RoomState represents a ROOMSTATE message.
+type RoomState struct {
+	Channel       string // Channel name
+	EmoteOnly     bool   // Emote-only mode
+	FollowersOnly int    // Followers-only mode (-1 = off, 0+ = minutes required)
+	R9K           bool   // R9K/unique mode
+	Slow          int    // Slow mode (seconds between messages, 0 = off)
+	SubsOnly      bool   // Subscribers-only mode
+	RoomID        string // Channel/room ID
+	Raw           string // Raw IRC message
+}
+
+// Notice represents a NOTICE message from the server.
+type Notice struct {
+	Channel   string // Channel name (may be empty for global notices)
+	Message   string // Notice message
+	MsgID     string // Notice type identifier
+	Raw       string // Raw IRC message
+}
+
+// Common Notice MsgIDs
+const (
+	NoticeMsgIDSubsOn           = "subs_on"
+	NoticeMsgIDSubsOff          = "subs_off"
+	NoticeMsgIDEmoteOnlyOn      = "emote_only_on"
+	NoticeMsgIDEmoteOnlyOff     = "emote_only_off"
+	NoticeMsgIDSlowOn           = "slow_on"
+	NoticeMsgIDSlowOff          = "slow_off"
+	NoticeMsgIDFollowersOn      = "followers_on"
+	NoticeMsgIDFollowersOff     = "followers_off"
+	NoticeMsgIDR9KOn            = "r9k_on"
+	NoticeMsgIDR9KOff           = "r9k_off"
+	NoticeMsgIDHostOn           = "host_on"
+	NoticeMsgIDHostOff          = "host_off"
+	NoticeMsgIDMsgChannelSuspended = "msg_channel_suspended"
+	NoticeMsgIDMsgBanned        = "msg_banned"
+	NoticeMsgIDMsgRateLimit     = "msg_ratelimit"
+	NoticeMsgIDMsgDuplicate     = "msg_duplicate"
+	NoticeMsgIDMsgFollowersOnly = "msg_followersonly"
+	NoticeMsgIDMsgSubsOnly      = "msg_subsonly"
+	NoticeMsgIDMsgEmoteOnly     = "msg_emoteonly"
+	NoticeMsgIDMsgSlowMode      = "msg_slowmode"
+	NoticeMsgIDMsgR9K           = "msg_r9k"
+	NoticeMsgIDNoPermission     = "no_permission"
+	NoticeMsgIDUnrecognizedCmd  = "unrecognized_cmd"
+)
+
+// ClearChat represents a CLEARCHAT message (timeout/ban).
+type ClearChat struct {
+	Channel       string        // Channel name
+	User          string        // User being cleared (empty = chat cleared)
+	BanDuration   int           // Duration in seconds (0 = permanent ban)
+	RoomID        string        // Channel ID
+	TargetUserID  string        // Banned user's ID
+	Timestamp     time.Time     // Server timestamp
+	Raw           string        // Raw IRC message
+}
+
+// ClearMessage represents a CLEARMSG message (single message deletion).
+type ClearMessage struct {
+	Channel       string    // Channel name
+	User          string    // Message author
+	Message       string    // Deleted message content
+	TargetMsgID   string    // ID of deleted message
+	Timestamp     time.Time // Server timestamp
+	Raw           string    // Raw IRC message
+}
+
+// Whisper represents a WHISPER message (direct message).
+type Whisper struct {
+	From        string            // Sender username
+	FromID      string            // Sender user ID
+	To          string            // Recipient username
+	Message     string            // Message content
+	DisplayName string            // Sender display name
+	Color       string            // Sender color
+	Badges      map[string]string // Sender badges
+	Emotes      []IRCEmote        // Emotes in message
+	MessageID   string            // Unique message ID
+	ThreadID    string            // Thread ID
+	Raw         string            // Raw IRC message
+}
+
+// GlobalUserState represents a GLOBALUSERSTATE message.
+type GlobalUserState struct {
+	UserID      string            // User's Twitch ID
+	DisplayName string            // Display name
+	Color       string            // Chat color
+	Badges      map[string]string // Global badges
+	BadgeInfo   map[string]string // Badge info
+	EmoteSets   []string          // Available emote set IDs
+	Raw         string            // Raw IRC message
+}
+
+// UserState represents a USERSTATE message.
+type UserState struct {
+	Channel     string            // Channel name
+	DisplayName string            // Display name
+	Color       string            // Chat color
+	Badges      map[string]string // Channel-specific badges
+	BadgeInfo   map[string]string // Badge info
+	EmoteSets   []string          // Available emote set IDs
+	IsMod       bool              // Is moderator
+	IsSubscriber bool             // Is subscriber
+	Raw         string            // Raw IRC message
+}
+
+// IRCMessage represents a parsed IRC message.
+type IRCMessage struct {
+	Raw     string            // Raw message
+	Tags    map[string]string // IRCv3 tags
+	Prefix  string            // Source prefix (nick!user@host)
+	Command string            // IRC command
+	Params  []string          // Command parameters
+	Trailing string           // Trailing parameter (after :)
+}


### PR DESCRIPTION
## Summary

- Full IRC/TMI chat client for building Twitch chat bots
- Message parsing with IRCv3 tags support (badges, emotes, etc.)
- Handlers for all major IRC events (messages, subs, raids, bans, etc.)
- High-level ChatBotClient wrapper with convenience methods
- Auto-reconnect and PING/PONG keepalive

## Changes

- `helix/irc.go` - Core IRC client with WebSocket connection
- `helix/irc_types.go` - IRC message type definitions
- `helix/irc_parser.go` - IRC message parser
- `helix/irc_test.go` - Unit tests
- `helix/chat_client.go` - High-level ChatBotClient wrapper
- `README.md` - Updated feature list

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual testing with Twitch IRC