### PR TITLE
Add CreateClipFromVOD API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `CreateClipFromVOD` - Create clips from existing VODs (POST /videos/clips)
+  - Requires `editor:manage:clips` or `channel:manage:clips` scope
+  - Supports custom duration (5-60 seconds)
 
 ### Changed
 

--- a/docs/clips.md
+++ b/docs/clips.md
@@ -1,6 +1,6 @@
 # Clips API
 
-Create and retrieve Twitch clips from broadcasts.
+Create and retrieve Twitch clips from broadcasts and VODs.
 
 ## CreateClip
 
@@ -39,6 +39,75 @@ fmt.Printf("Clip created! ID: %s, Edit URL: %s\n",
   ]
 }
 ```
+
+## CreateClipFromVOD
+
+Create a clip from an existing VOD (Video on Demand).
+
+**Requires:** `editor:manage:clips` or `channel:manage:clips` scope
+
+```go
+// Basic usage - create a 30-second clip (default duration)
+resp, err := client.CreateClipFromVOD(ctx, &helix.CreateClipFromVODParams{
+    EditorID:      "11111",      // User creating the clip
+    BroadcasterID: "22222",      // Channel owner
+    VODID:         "1234567890", // VOD to clip from
+    VODOffset:     3600,         // 1 hour into the VOD (where clip ends)
+    Title:         "Epic Play!",
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Clip created! ID: %s\n", resp.ID)
+fmt.Printf("Edit URL: %s\n", resp.EditURL)
+
+// With custom duration (5-60 seconds)
+duration := 45.0
+resp, err = client.CreateClipFromVOD(ctx, &helix.CreateClipFromVODParams{
+    EditorID:      "11111",
+    BroadcasterID: "22222",
+    VODID:         "1234567890",
+    VODOffset:     7200,         // 2 hours into the VOD
+    Title:         "Amazing Moment",
+    Duration:      &duration,    // 45 second clip
+})
+```
+
+**Parameters:**
+- `EditorID` (string, required): User ID of the editor creating the clip
+- `BroadcasterID` (string, required): User ID of the channel receiving the clip
+- `VODID` (string, required): ID of the VOD to create clip from
+- `VODOffset` (int, required): Offset in seconds where the clip ends in the VOD
+- `Title` (string, required): Title for the clip
+- `Duration` (*float64, optional): Clip length in seconds (5-60, default 30, precision 0.1)
+
+**Returns:**
+- `ID` (string): The newly created clip ID
+- `EditURL` (string): URL where the clip can be edited
+
+**Sample Response:**
+```json
+{
+  "data": [
+    {
+      "id": "VODClipAwesome123",
+      "edit_url": "https://clips.twitch.tv/VODClipAwesome123/edit"
+    }
+  ]
+}
+```
+
+**Example Output:**
+```
+Clip created! ID: VODClipAwesome123
+Edit URL: https://clips.twitch.tv/VODClipAwesome123/edit
+```
+
+**Notes:**
+- The `VODOffset` specifies where the clip **ends**, not where it starts
+- The clip will include content from `(VODOffset - Duration)` to `VODOffset`
+- Duration defaults to 30 seconds if not specified
+- Duration must be between 5 and 60 seconds
 
 ## GetClips
 

--- a/helix/clips.go
+++ b/helix/clips.go
@@ -124,3 +124,26 @@ func (c *Client) GetClipsDownload(ctx context.Context, clipIDs []string) (*Respo
 	}
 	return &resp, nil
 }
+
+// CreateClipFromVODParams contains parameters for CreateClipFromVOD.
+type CreateClipFromVODParams struct {
+	EditorID      string   `json:"editor_id"`      // Required: User ID of the editor
+	BroadcasterID string   `json:"broadcaster_id"` // Required: User ID of the channel
+	VODID         string   `json:"vod_id"`         // Required: ID of the VOD to clip
+	VODOffset     int      `json:"vod_offset"`     // Required: Offset in seconds where clip ends
+	Title         string   `json:"title"`          // Required: Clip title
+	Duration      *float64 `json:"duration,omitempty"` // Optional: Clip length (5-60 seconds, default 30)
+}
+
+// CreateClipFromVOD creates a clip from a VOD.
+// Requires: editor:manage:clips or channel:manage:clips scope.
+func (c *Client) CreateClipFromVOD(ctx context.Context, params *CreateClipFromVODParams) (*CreateClipResponse, error) {
+	var resp Response[CreateClipResponse]
+	if err := c.post(ctx, "/videos/clips", nil, params, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Data) == 0 {
+		return nil, nil
+	}
+	return &resp.Data[0], nil
+}


### PR DESCRIPTION
## Summary
- Adds support for the new Create Clip from VOD endpoint (POST /videos/clips)
- Allows creating clips from existing VODs rather than live streams
- Requires `editor:manage:clips` or `channel:manage:clips` scope

## Changes
- `helix/clips.go`: New `CreateClipFromVOD` function and `CreateClipFromVODParams` struct
- `helix/clips_test.go`: 4 test cases covering success, custom duration, errors, and empty response
- `docs/clips.md`: Full documentation with examples and sample output
- `CHANGELOG.md`: Added entry under [Unreleased]

## Test plan
- [x] All tests pass locally
- [x] Documentation includes usage examples