### PR TITLE
Add PubSub compatibility layer backed by EventSub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, test]
   pull_request:
-    branches: [main]
+    branches: [main, test]
 
 jobs:
   test:
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -29,13 +29,25 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Generate coverage report
         if: matrix.go-version == '1.23'
+        run: |
+          go tool cover -func=coverage.out -o=coverage.txt
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}')
+          echo "## Test Coverage: ${COVERAGE}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Package | Coverage |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|----------|" >> $GITHUB_STEP_SUMMARY
+          go tool cover -func=coverage.out | grep -v "total:" | awk '{print "| " $1 " | " $3 " |"}' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload coverage artifact
+        if: matrix.go-version == '1.23'
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.out
-          fail_ci_if_error: false
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.txt
 
   lint:
     name: Lint
@@ -43,15 +55,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
 
@@ -61,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 

--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -375,3 +375,15 @@ This document lists all Twitch API endpoints and indicates whether they are supp
 - **Authentication/OIDC endpoints** use a different base URL (`https://id.twitch.tv/oauth2`) and support OpenID Connect flows
 - **EventSub** includes webhook handler with signature verification, challenge response, and event type definitions
 - **Extension JWT** authentication is supported for extension backend services
+
+### Real-Time Features (Non-REST)
+
+In addition to REST API endpoints, this library supports:
+
+| Feature | Protocol | Description |
+|---------|----------|-------------|
+| IRC/TMI Chat | WebSocket | Full chat client with message parsing, subs, raids, moderation |
+| EventSub WebSocket | WebSocket | Real-time event streaming with auto-reconnect |
+| PubSub Compatibility | WebSocket | PubSub-style API backed by EventSub (migration layer) |
+
+The **PubSub Compatibility** layer provides familiar `Listen(topic)`/`Unlisten(topic)` semantics for developers migrating from the deprecated Twitch PubSub system (decommissioned April 2025). It internally uses EventSub WebSocket.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kappopher
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/Its-donkey/kappopher)](https://goreportcard.com/report/github.com/Its-donkey/kappopher)
-[![codecov](https://codecov.io/github/Its-donkey/kappopher/graph/badge.svg?token=UB85N281NS)](https://codecov.io/github/Its-donkey/kappopher)
+[![Tests](https://github.com/Its-donkey/kappopher/actions/workflows/test.yml/badge.svg)](https://github.com/Its-donkey/kappopher/actions/workflows/test.yml)
 
 A comprehensive Twitch API toolkit for Go.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Kappopher
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/Its-donkey/kappopher.svg)](https://pkg.go.dev/github.com/Its-donkey/kappopher)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Its-donkey/kappopher)](https://goreportcard.com/report/github.com/Its-donkey/kappopher)
 [![Tests](https://github.com/Its-donkey/kappopher/actions/workflows/test.yml/badge.svg)](https://github.com/Its-donkey/kappopher/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/Its-donkey/kappopher)](https://github.com/Its-donkey/kappopher)
 
 A comprehensive Twitch API toolkit for Go.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kappopher
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/Its-donkey/kappopher)](https://goreportcard.com/report/github.com/Its-donkey/kappopher)
-[![codecov](https://codecov.io/github/Its-donkey/helix/graph/badge.svg?token=UB85N281NS)](https://codecov.io/github/Its-donkey/helix)
+[![codecov](https://codecov.io/github/Its-donkey/kappopher/graph/badge.svg?token=UB85N281NS)](https://codecov.io/github/Its-donkey/kappopher)
 
 A comprehensive Twitch API toolkit for Go.
 
@@ -13,6 +13,7 @@ A comprehensive Twitch API toolkit for Go.
 - **IRC/TMI Chat**: Full IRC chat client for building chat bots with message parsing, subs, raids, and moderation events
 - **EventSub Webhooks**: Built-in webhook handler with signature verification and event parsing
 - **EventSub WebSocket**: Real-time event streaming with automatic keepalive and reconnection
+- **PubSub Compatibility**: Migration layer providing familiar PubSub-style API backed by EventSub
 - **Extension JWT**: Full support for Twitch Extension authentication
 - **Caching Layer**: Built-in response caching with TTL support
 - **Middleware System**: Chainable request/response middleware
@@ -72,6 +73,7 @@ func main() {
 | IRC/TMI Chat | Yes | Varies |
 | EventSub WebSocket | Yes | No |
 | EventSub Conduits | Yes | Varies |
+| PubSub Compatibility Layer | Yes | No |
 | Middleware System | Yes | No |
 | Caching Layer | Yes | No |
 | Batch Operations | Yes | No |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This documentation provides detailed guides and examples for using the Twitch He
 | [Conduits](conduits.md) | EventSub conduit management |
 | [Entitlements](entitlements.md) | Drops entitlements |
 | [EventSub](eventsub.md) | Event subscriptions |
+| [PubSub Compatibility](pubsub-compat.md) | PubSub-style API backed by EventSub |
 | [Extensions](extensions.md) | Extension management |
 | [Games](games.md) | Game information |
 | [Goals](goals.md) | Creator goals, hype train |
@@ -52,4 +53,5 @@ See the [examples](./examples/) directory for code samples:
 - [API Usage](./examples/api-usage.md) - Common API patterns
 - [EventSub Webhooks](./examples/eventsub-webhooks.md) - Webhook notifications
 - [EventSub WebSocket](./examples/eventsub-websocket.md) - Real-time events
+- [PubSub Migration](./examples/pubsub-migration.md) - Migrating from PubSub to EventSub
 - [Extension JWT](./examples/extension-jwt.md) - Extension authentication

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -19,6 +19,7 @@ Code examples for common use cases.
 
 - [EventSub Webhooks](eventsub-webhooks.md) - Handle webhook notifications with signature verification
 - [EventSub WebSocket](eventsub-websocket.md) - Real-time event streaming without a public endpoint
+- [PubSub Migration](pubsub-migration.md) - PubSub-style API using EventSub (for migration from deprecated PubSub)
 
 ## Extensions
 

--- a/docs/examples/pubsub-migration.md
+++ b/docs/examples/pubsub-migration.md
@@ -1,0 +1,235 @@
+# PubSub Migration Example
+
+This example demonstrates how to use the PubSub compatibility layer to receive real-time events using familiar PubSub-style topic subscriptions.
+
+> **Note:** Twitch PubSub was decommissioned on April 14, 2025. This compatibility layer uses EventSub WebSocket internally but provides a PubSub-like API for easier migration.
+
+## Basic Usage
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "log"
+    "os"
+    "os/signal"
+
+    "github.com/Its-donkey/kappopher/helix"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // Create auth client
+    authClient := helix.NewAuthClient(helix.AuthConfig{
+        ClientID:     os.Getenv("TWITCH_CLIENT_ID"),
+        ClientSecret: os.Getenv("TWITCH_CLIENT_SECRET"),
+    })
+
+    // Get app access token
+    token, err := authClient.GetAppAccessToken(ctx)
+    if err != nil {
+        log.Fatalf("Failed to get token: %v", err)
+    }
+    authClient.SetToken(token)
+
+    // Create Helix client
+    helixClient := helix.NewClient(os.Getenv("TWITCH_CLIENT_ID"), authClient)
+
+    // Create PubSub client with handlers
+    pubsub := helix.NewPubSubClient(helixClient,
+        helix.WithPubSubMessageHandler(handleMessage),
+        helix.WithPubSubErrorHandler(handleError),
+        helix.WithPubSubConnectHandler(func() {
+            log.Println("Connected to EventSub")
+        }),
+        helix.WithPubSubReconnectHandler(func() {
+            log.Println("Reconnected to EventSub")
+        }),
+    )
+
+    // Connect
+    if err := pubsub.Connect(ctx); err != nil {
+        log.Fatalf("Failed to connect: %v", err)
+    }
+    defer pubsub.Close(ctx)
+
+    channelID := "12345" // Replace with actual channel ID
+
+    // Listen to topics (familiar PubSub-style API)
+    topics := []string{
+        helix.BuildTopic("channel-points-channel-v1", channelID),
+        helix.BuildTopic("channel-subscribe-events-v1", channelID),
+        helix.BuildTopic("channel-bits-events-v2", channelID),
+    }
+
+    for _, topic := range topics {
+        if err := pubsub.Listen(ctx, topic); err != nil {
+            log.Printf("Failed to listen to %s: %v", topic, err)
+        } else {
+            log.Printf("Listening to: %s", topic)
+        }
+    }
+
+    // Wait for interrupt signal
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, os.Interrupt)
+    <-sigChan
+
+    log.Println("Shutting down...")
+}
+
+func handleMessage(topic string, message json.RawMessage) {
+    // Parse the envelope
+    var envelope helix.PubSubMessage
+    if err := json.Unmarshal(message, &envelope); err != nil {
+        log.Printf("Failed to parse envelope: %v", err)
+        return
+    }
+
+    log.Printf("Event on %s (type: %s)", topic, envelope.Type)
+
+    // Route to specific handler based on EventSub type
+    switch envelope.Type {
+    case helix.EventSubTypeChannelPointsRedemptionAdd:
+        handleRedemption(envelope.Data)
+    case helix.EventSubTypeChannelCheer:
+        handleCheer(envelope.Data)
+    case helix.EventSubTypeChannelSubscribe:
+        handleSubscription(envelope.Data)
+    case helix.EventSubTypeChannelSubscriptionGift:
+        handleGiftSub(envelope.Data)
+    case helix.EventSubTypeChannelSubscriptionMessage:
+        handleResub(envelope.Data)
+    default:
+        log.Printf("Unhandled event type: %s", envelope.Type)
+    }
+}
+
+func handleRedemption(data json.RawMessage) {
+    var event helix.ChannelPointsRedemptionAddEvent
+    if err := json.Unmarshal(data, &event); err != nil {
+        log.Printf("Failed to parse redemption: %v", err)
+        return
+    }
+    fmt.Printf("🎁 %s redeemed '%s' for %d points\n",
+        event.UserName, event.Reward.Title, event.Reward.Cost)
+}
+
+func handleCheer(data json.RawMessage) {
+    var event helix.ChannelCheerEvent
+    if err := json.Unmarshal(data, &event); err != nil {
+        log.Printf("Failed to parse cheer: %v", err)
+        return
+    }
+    fmt.Printf("💎 %s cheered %d bits: %s\n",
+        event.UserName, event.Bits, event.Message)
+}
+
+func handleSubscription(data json.RawMessage) {
+    var event helix.ChannelSubscribeEvent
+    if err := json.Unmarshal(data, &event); err != nil {
+        log.Printf("Failed to parse subscription: %v", err)
+        return
+    }
+    fmt.Printf("⭐ New subscriber: %s (Tier %s)\n",
+        event.UserName, event.Tier)
+}
+
+func handleGiftSub(data json.RawMessage) {
+    var event helix.ChannelSubscriptionGiftEvent
+    if err := json.Unmarshal(data, &event); err != nil {
+        log.Printf("Failed to parse gift sub: %v", err)
+        return
+    }
+    fmt.Printf("🎉 %s gifted %d subs!\n",
+        event.UserName, event.Total)
+}
+
+func handleResub(data json.RawMessage) {
+    var event helix.ChannelSubscriptionMessageEvent
+    if err := json.Unmarshal(data, &event); err != nil {
+        log.Printf("Failed to parse resub: %v", err)
+        return
+    }
+    fmt.Printf("🔄 %s resubscribed for %d months: %s\n",
+        event.UserName, event.CumulativeMonths, event.Message.Text)
+}
+
+func handleError(err error) {
+    log.Printf("PubSub error: %v", err)
+}
+```
+
+## Multiple Channels
+
+You can listen to multiple channels by creating multiple topic strings:
+
+```go
+channels := []string{"12345", "67890", "11111"}
+
+for _, channelID := range channels {
+    topic := helix.BuildTopic("channel-points-channel-v1", channelID)
+    if err := pubsub.Listen(ctx, topic); err != nil {
+        log.Printf("Failed to listen to channel %s: %v", channelID, err)
+    }
+}
+```
+
+## Dynamic Subscribe/Unsubscribe
+
+You can add and remove subscriptions at runtime:
+
+```go
+// Add a new topic
+newTopic := helix.BuildTopic("channel-bits-events-v1", "99999")
+pubsub.Listen(ctx, newTopic)
+
+// Remove a topic
+pubsub.Unlisten(ctx, newTopic)
+
+// Check current topics
+for _, topic := range pubsub.Topics() {
+    fmt.Println("Active:", topic)
+}
+```
+
+## Supported Topics Reference
+
+```go
+// Check what topics are supported
+for _, pattern := range helix.SupportedTopics() {
+    fmt.Println(pattern)
+}
+
+// Check what EventSub types a topic maps to
+types := helix.TopicEventSubTypes("channel-subscribe-events-v1.12345")
+fmt.Println(types) // [channel.subscribe, channel.subscription.gift, channel.subscription.message]
+```
+
+## Migration Checklist
+
+When migrating from old PubSub code:
+
+1. ✅ Replace direct PubSub connection with `helix.NewPubSubClient`
+2. ✅ Add `context.Context` to all calls
+3. ✅ Update message handler to parse `PubSubMessage` envelope
+4. ✅ Update event parsing to use EventSub types (slightly different field names)
+5. ✅ Handle that some topics create multiple EventSub subscriptions
+6. ✅ Test with actual Twitch events
+
+## EventSub Event Types
+
+For reference, here are the EventSub event types that PubSub topics map to:
+
+| Topic Pattern | EventSub Types |
+|---------------|----------------|
+| `channel-bits-events-*` | `channel.cheer` |
+| `channel-points-channel-v1` | `channel.channel_points_custom_reward_redemption.add` |
+| `channel-subscribe-events-v1` | `channel.subscribe`, `channel.subscription.gift`, `channel.subscription.message` |
+| `automod-queue` | `automod.message.hold` |
+| `chat_moderator_actions` | `channel.moderate` |
+| `whispers` | `user.whisper.message` |

--- a/docs/pubsub-compat.md
+++ b/docs/pubsub-compat.md
@@ -1,0 +1,320 @@
+# PubSub Compatibility Layer
+
+The PubSub compatibility layer provides a familiar PubSub-style API (`Listen`/`Unlisten` with topic strings) while internally using EventSub WebSocket. This enables a smooth migration path for developers transitioning from the deprecated Twitch PubSub system.
+
+> **Note:** Twitch PubSub was fully decommissioned on April 14, 2025. This compatibility layer uses EventSub under the hood, which is Twitch's current real-time event system.
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "log"
+
+    "github.com/Its-donkey/kappopher/helix"
+)
+
+func main() {
+    // Create auth client and get token
+    authClient := helix.NewAuthClient(helix.AuthConfig{
+        ClientID:     "your-client-id",
+        ClientSecret: "your-client-secret",
+    })
+    token, _ := authClient.GetAppAccessToken(context.Background())
+    authClient.SetToken(token)
+
+    // Create Helix client
+    helixClient := helix.NewClient("your-client-id", authClient)
+
+    // Create PubSub client
+    pubsub := helix.NewPubSubClient(helixClient,
+        helix.WithPubSubMessageHandler(func(topic string, message json.RawMessage) {
+            fmt.Printf("Received on %s: %s\n", topic, string(message))
+        }),
+        helix.WithPubSubErrorHandler(func(err error) {
+            log.Printf("Error: %v\n", err)
+        }),
+    )
+
+    // Connect
+    ctx := context.Background()
+    if err := pubsub.Connect(ctx); err != nil {
+        log.Fatal(err)
+    }
+    defer pubsub.Close(ctx)
+
+    // Listen to topics (familiar PubSub-style!)
+    pubsub.Listen(ctx, "channel-points-channel-v1.12345")
+    pubsub.Listen(ctx, "channel-subscribe-events-v1.12345")
+
+    // Block forever (in real app, use proper signal handling)
+    select {}
+}
+```
+
+## Supported Topics
+
+The following PubSub topics are supported and automatically mapped to their EventSub equivalents:
+
+| PubSub Topic | EventSub Type(s) |
+|--------------|------------------|
+| `channel-bits-events-v1.<channel_id>` | `channel.cheer` |
+| `channel-bits-events-v2.<channel_id>` | `channel.cheer` |
+| `channel-bits-badge-unlocks.<channel_id>` | `channel.chat.notification` |
+| `channel-points-channel-v1.<channel_id>` | `channel.channel_points_custom_reward_redemption.add` |
+| `channel-subscribe-events-v1.<channel_id>` | `channel.subscribe`, `channel.subscription.gift`, `channel.subscription.message` |
+| `automod-queue.<moderator_id>.<channel_id>` | `automod.message.hold` |
+| `chat_moderator_actions.<user_id>.<channel_id>` | `channel.moderate` |
+| `whispers.<user_id>` | `user.whisper.message` |
+
+## API Reference
+
+### NewPubSubClient
+
+Creates a new PubSub compatibility client.
+
+```go
+pubsub := helix.NewPubSubClient(helixClient, opts...)
+```
+
+**Parameters:**
+- `helixClient` (*Client): The Helix API client for creating subscriptions
+- `opts` (...PubSubOption): Optional configuration functions
+
+### Options
+
+```go
+// Set message handler for all topics
+helix.WithPubSubMessageHandler(func(topic string, message json.RawMessage) {
+    // Handle messages
+})
+
+// Set error handler
+helix.WithPubSubErrorHandler(func(err error) {
+    // Handle errors
+})
+
+// Set connection handler
+helix.WithPubSubConnectHandler(func() {
+    // Called when connected
+})
+
+// Set reconnection handler
+helix.WithPubSubReconnectHandler(func() {
+    // Called after successful reconnection
+})
+
+// Set custom WebSocket URL (for testing)
+helix.WithPubSubWSURL("wss://custom.example.com/ws")
+```
+
+### Connect
+
+Establishes the WebSocket connection to EventSub.
+
+```go
+err := pubsub.Connect(ctx)
+```
+
+### Listen
+
+Subscribes to a PubSub topic. The topic is automatically translated to the equivalent EventSub subscription(s).
+
+```go
+err := pubsub.Listen(ctx, "channel-points-channel-v1.12345")
+```
+
+**Notes:**
+- Some topics map to multiple EventSub subscriptions (e.g., `channel-subscribe-events-v1` creates 3 subscriptions)
+- Listening to the same topic twice is idempotent (no error, no duplicate subscriptions)
+- Returns `ErrPubSubNotConnected` if not connected
+- Returns `ErrPubSubInvalidTopic` for unrecognized topic formats
+- Returns `ErrPubSubUnsupportedTopic` for valid but unsupported topic types
+
+### Unlisten
+
+Unsubscribes from a PubSub topic.
+
+```go
+err := pubsub.Unlisten(ctx, "channel-points-channel-v1.12345")
+```
+
+### Close
+
+Closes the connection and cleans up all subscriptions.
+
+```go
+err := pubsub.Close(ctx)
+```
+
+### IsConnected
+
+Returns whether the client is currently connected.
+
+```go
+if pubsub.IsConnected() {
+    // Connected
+}
+```
+
+### Topics
+
+Returns the list of topics currently being listened to.
+
+```go
+topics := pubsub.Topics()
+for _, topic := range topics {
+    fmt.Println(topic)
+}
+```
+
+### SessionID
+
+Returns the EventSub session ID.
+
+```go
+sessionID := pubsub.SessionID()
+```
+
+## Helper Functions
+
+### ParseTopic
+
+Parses a PubSub topic string into its components.
+
+```go
+parsed, err := helix.ParseTopic("channel-points-channel-v1.12345")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Type: %s, ChannelID: %s\n", parsed.Type, parsed.ChannelID)
+```
+
+### BuildTopic
+
+Constructs a PubSub topic string from components.
+
+```go
+topic := helix.BuildTopic("channel-points-channel-v1", "12345")
+// Returns: "channel-points-channel-v1.12345"
+
+topic = helix.BuildTopic("automod-queue", "mod_id", "channel_id")
+// Returns: "automod-queue.mod_id.channel_id"
+```
+
+### TopicEventSubTypes
+
+Returns the EventSub types that a PubSub topic maps to.
+
+```go
+types := helix.TopicEventSubTypes("channel-subscribe-events-v1.12345")
+// Returns: ["channel.subscribe", "channel.subscription.gift", "channel.subscription.message"]
+```
+
+### SupportedTopics
+
+Returns a list of all supported topic patterns.
+
+```go
+patterns := helix.SupportedTopics()
+for _, pattern := range patterns {
+    fmt.Println(pattern)
+}
+```
+
+## Message Format
+
+Messages are delivered to your handler wrapped in a `PubSubMessage` envelope:
+
+```go
+type PubSubMessage struct {
+    Type string          `json:"type"` // EventSub subscription type
+    Data json.RawMessage `json:"data"` // EventSub event payload
+}
+```
+
+Example handler that parses the message:
+
+```go
+helix.WithPubSubMessageHandler(func(topic string, message json.RawMessage) {
+    var envelope helix.PubSubMessage
+    json.Unmarshal(message, &envelope)
+
+    switch envelope.Type {
+    case helix.EventSubTypeChannelPointsRedemptionAdd:
+        var event helix.ChannelPointsRedemptionAddEvent
+        json.Unmarshal(envelope.Data, &event)
+        fmt.Printf("Redemption: %s redeemed %s\n",
+            event.UserName, event.Reward.Title)
+
+    case helix.EventSubTypeChannelCheer:
+        var event helix.ChannelCheerEvent
+        json.Unmarshal(envelope.Data, &event)
+        fmt.Printf("Cheer: %s cheered %d bits\n",
+            event.UserName, event.Bits)
+    }
+})
+```
+
+## Error Handling
+
+The client handles several error scenarios:
+
+```go
+helix.WithPubSubErrorHandler(func(err error) {
+    switch {
+    case errors.Is(err, helix.ErrPubSubNotConnected):
+        // Not connected to WebSocket
+    case errors.Is(err, helix.ErrPubSubInvalidTopic):
+        // Topic format not recognized
+    case errors.Is(err, helix.ErrPubSubUnsupportedTopic):
+        // Topic type not supported
+    default:
+        // Other errors (subscription revocation, reconnection failures, etc.)
+        log.Printf("PubSub error: %v", err)
+    }
+})
+```
+
+## Reconnection
+
+The client automatically handles EventSub reconnection requests. When the server requests a reconnection:
+
+1. The client connects to the new URL provided by Twitch
+2. A new session is established
+3. Your `onReconnect` handler is called
+4. All existing topic subscriptions remain active (EventSub handles this automatically)
+
+```go
+helix.WithPubSubReconnectHandler(func() {
+    log.Println("Successfully reconnected to EventSub")
+})
+```
+
+## Migration from PubSub
+
+If you're migrating from the old PubSub system, the API is intentionally similar:
+
+**Old PubSub code:**
+```go
+// Old: Direct PubSub (no longer works)
+pubsub.Listen("channel-points-channel-v1.12345", token)
+```
+
+**New Kappopher code:**
+```go
+// New: PubSub compatibility layer (uses EventSub)
+pubsub := helix.NewPubSubClient(helixClient, ...)
+pubsub.Connect(ctx)
+pubsub.Listen(ctx, "channel-points-channel-v1.12345")
+```
+
+Key differences:
+1. Requires a Helix client (for creating EventSub subscriptions via API)
+2. Uses `context.Context` for all operations
+3. Messages are wrapped in a `PubSubMessage` envelope with the EventSub type
+4. Event payloads use EventSub format (not old PubSub format)

--- a/helix/pubsub_compat.go
+++ b/helix/pubsub_compat.go
@@ -1,0 +1,552 @@
+package helix
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// PubSub compatibility errors.
+var (
+	ErrPubSubNotConnected     = errors.New("pubsub: not connected")
+	ErrPubSubInvalidTopic     = errors.New("pubsub: invalid topic format")
+	ErrPubSubUnsupportedTopic = errors.New("pubsub: topic type not supported")
+)
+
+// ParsedTopic represents a parsed PubSub topic string.
+type ParsedTopic struct {
+	Type        string // e.g., "channel-bits-events", "channel-points-channel"
+	ChannelID   string // broadcaster/channel ID
+	UserID      string // user ID (for whispers, moderator actions)
+	ModeratorID string // moderator ID (for automod)
+}
+
+// TopicMapping defines how a PubSub topic maps to EventSub subscriptions.
+type TopicMapping struct {
+	EventSubTypes []string                                    // EventSub subscription types
+	Condition     func(parsed *ParsedTopic) map[string]string // Build condition from parsed topic
+}
+
+// Topic patterns for parsing PubSub topic strings.
+var topicPatterns = map[string]*regexp.Regexp{
+	"channel-bits-events":    regexp.MustCompile(`^channel-bits-events-v[12]\.(\d+)$`),
+	"channel-bits-badge":     regexp.MustCompile(`^channel-bits-badge-unlocks\.(\d+)$`),
+	"channel-points-channel": regexp.MustCompile(`^channel-points-channel-v1\.(\d+)$`),
+	"channel-subscribe":      regexp.MustCompile(`^channel-subscribe-events-v1\.(\d+)$`),
+	"automod-queue":          regexp.MustCompile(`^automod-queue\.(\d+)\.(\d+)$`),
+	"chat-moderator-actions": regexp.MustCompile(`^chat_moderator_actions\.(\d+)\.(\d+)$`),
+	"whispers":               regexp.MustCompile(`^whispers\.(\d+)$`),
+}
+
+// topicMappings maps PubSub topic types to EventSub subscriptions.
+var topicMappings = map[string]TopicMapping{
+	"channel-bits-events": {
+		EventSubTypes: []string{EventSubTypeChannelCheer},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterCondition(p.ChannelID)
+		},
+	},
+	"channel-bits-badge": {
+		// EventSub uses channel.chat.notification for bits badge unlocks
+		EventSubTypes: []string{EventSubTypeChannelChatNotification},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterCondition(p.ChannelID)
+		},
+	},
+	"channel-points-channel": {
+		EventSubTypes: []string{EventSubTypeChannelPointsRedemptionAdd},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterCondition(p.ChannelID)
+		},
+	},
+	"channel-subscribe": {
+		// Multiple EventSub types for one PubSub topic
+		EventSubTypes: []string{
+			EventSubTypeChannelSubscribe,
+			EventSubTypeChannelSubscriptionGift,
+			EventSubTypeChannelSubscriptionMessage,
+		},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterCondition(p.ChannelID)
+		},
+	},
+	"automod-queue": {
+		EventSubTypes: []string{EventSubTypeAutomodMessageHold},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterModeratorCondition(p.ChannelID, p.ModeratorID)
+		},
+	},
+	"chat-moderator-actions": {
+		EventSubTypes: []string{EventSubTypeChannelModerate},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return BroadcasterModeratorCondition(p.ChannelID, p.UserID)
+		},
+	},
+	"whispers": {
+		EventSubTypes: []string{EventSubTypeUserWhisperMessage},
+		Condition: func(p *ParsedTopic) map[string]string {
+			return UserCondition(p.UserID)
+		},
+	},
+}
+
+// ParseTopic parses a PubSub topic string into its components.
+func ParseTopic(topic string) (*ParsedTopic, error) {
+	// Handle channel-bits-events-v1.<channel_id> and v2
+	if matches := topicPatterns["channel-bits-events"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:      "channel-bits-events",
+			ChannelID: matches[1],
+		}, nil
+	}
+
+	// Handle channel-bits-badge-unlocks.<channel_id>
+	if matches := topicPatterns["channel-bits-badge"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:      "channel-bits-badge",
+			ChannelID: matches[1],
+		}, nil
+	}
+
+	// Handle channel-points-channel-v1.<channel_id>
+	if matches := topicPatterns["channel-points-channel"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:      "channel-points-channel",
+			ChannelID: matches[1],
+		}, nil
+	}
+
+	// Handle channel-subscribe-events-v1.<channel_id>
+	if matches := topicPatterns["channel-subscribe"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:      "channel-subscribe",
+			ChannelID: matches[1],
+		}, nil
+	}
+
+	// Handle automod-queue.<moderator_id>.<channel_id>
+	if matches := topicPatterns["automod-queue"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:        "automod-queue",
+			ModeratorID: matches[1],
+			ChannelID:   matches[2],
+		}, nil
+	}
+
+	// Handle chat_moderator_actions.<user_id>.<channel_id>
+	if matches := topicPatterns["chat-moderator-actions"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:      "chat-moderator-actions",
+			UserID:    matches[1],
+			ChannelID: matches[2],
+		}, nil
+	}
+
+	// Handle whispers.<user_id>
+	if matches := topicPatterns["whispers"].FindStringSubmatch(topic); matches != nil {
+		return &ParsedTopic{
+			Type:   "whispers",
+			UserID: matches[1],
+		}, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrPubSubInvalidTopic, topic)
+}
+
+// PubSubMessage wraps EventSub events in a PubSub-style envelope.
+type PubSubMessage struct {
+	Type string          `json:"type"` // EventSub subscription type
+	Data json.RawMessage `json:"data"` // EventSub event payload
+}
+
+// PubSubClient provides a PubSub-style API backed by EventSub.
+// This enables migration from the deprecated Twitch PubSub to EventSub
+// while maintaining familiar topic-based semantics.
+type PubSubClient struct {
+	client    *Client                  // Helix API client
+	ws        *EventSubWebSocketClient // Internal WebSocket
+	wsURL     string                   // Custom WebSocket URL (for testing)
+	sessionID string
+
+	// Topic tracking: maps PubSub topic -> EventSub subscription IDs
+	topics     map[string][]string // topic -> subscription IDs
+	subToTopic map[string]string   // subscription ID -> topic
+
+	// Handlers
+	onMessage   func(topic string, message json.RawMessage)
+	onError     func(error)
+	onConnect   func()
+	onReconnect func()
+
+	mu sync.RWMutex
+}
+
+// PubSubOption configures the PubSubClient.
+type PubSubOption func(*PubSubClient)
+
+// WithPubSubMessageHandler sets the handler for topic messages.
+func WithPubSubMessageHandler(fn func(topic string, message json.RawMessage)) PubSubOption {
+	return func(c *PubSubClient) {
+		c.onMessage = fn
+	}
+}
+
+// WithPubSubErrorHandler sets the handler for errors.
+func WithPubSubErrorHandler(fn func(error)) PubSubOption {
+	return func(c *PubSubClient) {
+		c.onError = fn
+	}
+}
+
+// WithPubSubConnectHandler sets the handler for connection events.
+func WithPubSubConnectHandler(fn func()) PubSubOption {
+	return func(c *PubSubClient) {
+		c.onConnect = fn
+	}
+}
+
+// WithPubSubReconnectHandler sets the handler for reconnection events.
+func WithPubSubReconnectHandler(fn func()) PubSubOption {
+	return func(c *PubSubClient) {
+		c.onReconnect = fn
+	}
+}
+
+// WithPubSubWSURL sets a custom WebSocket URL (useful for testing).
+func WithPubSubWSURL(url string) PubSubOption {
+	return func(c *PubSubClient) {
+		c.wsURL = url
+	}
+}
+
+// NewPubSubClient creates a new PubSub compatibility client.
+// The client uses EventSub WebSocket internally but exposes a PubSub-style API.
+func NewPubSubClient(helixClient *Client, opts ...PubSubOption) *PubSubClient {
+	c := &PubSubClient{
+		client:     helixClient,
+		topics:     make(map[string][]string),
+		subToTopic: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Connect establishes the WebSocket connection.
+func (c *PubSubClient) Connect(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ws != nil && c.ws.IsConnected() {
+		return nil // Already connected
+	}
+
+	// Build WebSocket options
+	wsOpts := []EventSubWSOption{
+		WithWSNotificationHandler(c.handleNotification),
+		WithWSRevocationHandler(c.handleRevocation),
+		WithWSReconnectHandler(c.handleReconnect),
+		WithWSErrorHandler(c.handleError),
+	}
+
+	if c.wsURL != "" {
+		wsOpts = append(wsOpts, WithWSURL(c.wsURL))
+	}
+
+	c.ws = NewEventSubWebSocketClient(wsOpts...)
+
+	sessionID, err := c.ws.Connect(ctx)
+	if err != nil {
+		return fmt.Errorf("connecting to EventSub: %w", err)
+	}
+
+	c.sessionID = sessionID
+
+	if c.onConnect != nil {
+		c.onConnect()
+	}
+
+	return nil
+}
+
+// Listen subscribes to a PubSub topic.
+// The topic is translated to the equivalent EventSub subscription(s).
+func (c *PubSubClient) Listen(ctx context.Context, topic string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ws == nil || !c.ws.IsConnected() {
+		return ErrPubSubNotConnected
+	}
+
+	// Check if already listening
+	if _, exists := c.topics[topic]; exists {
+		return nil // Already subscribed
+	}
+
+	// Parse topic
+	parsed, err := ParseTopic(topic)
+	if err != nil {
+		return err
+	}
+
+	// Get mapping
+	mapping, exists := topicMappings[parsed.Type]
+	if !exists {
+		return fmt.Errorf("%w: %s", ErrPubSubUnsupportedTopic, parsed.Type)
+	}
+
+	// Build condition
+	condition := mapping.Condition(parsed)
+
+	// Create EventSub subscriptions
+	var subIDs []string
+	transport := CreateEventSubTransport{
+		Method:    EventSubTransportWebSocket,
+		SessionID: c.sessionID,
+	}
+
+	for _, eventType := range mapping.EventSubTypes {
+		sub, err := c.client.CreateEventSubSubscription(ctx, &CreateEventSubSubscriptionParams{
+			Type:      eventType,
+			Version:   GetEventSubVersion(eventType),
+			Condition: condition,
+			Transport: transport,
+		})
+		if err != nil {
+			// Cleanup any created subscriptions on failure
+			for _, id := range subIDs {
+				_ = c.client.DeleteEventSubSubscription(ctx, id)
+			}
+			return fmt.Errorf("creating subscription for %s: %w", eventType, err)
+		}
+
+		subIDs = append(subIDs, sub.ID)
+		c.subToTopic[sub.ID] = topic
+	}
+
+	c.topics[topic] = subIDs
+	return nil
+}
+
+// Unlisten unsubscribes from a PubSub topic.
+func (c *PubSubClient) Unlisten(ctx context.Context, topic string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	subIDs, exists := c.topics[topic]
+	if !exists {
+		return nil // Not listening
+	}
+
+	var lastErr error
+	for _, id := range subIDs {
+		if err := c.client.DeleteEventSubSubscription(ctx, id); err != nil {
+			lastErr = err
+		}
+		delete(c.subToTopic, id)
+	}
+
+	delete(c.topics, topic)
+	return lastErr
+}
+
+// Close closes the PubSub client and cleans up all subscriptions.
+func (c *PubSubClient) Close(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Delete all subscriptions
+	for _, subIDs := range c.topics {
+		for _, id := range subIDs {
+			_ = c.client.DeleteEventSubSubscription(ctx, id)
+		}
+	}
+	c.topics = make(map[string][]string)
+	c.subToTopic = make(map[string]string)
+
+	// Close WebSocket
+	if c.ws != nil {
+		return c.ws.Close()
+	}
+
+	return nil
+}
+
+// IsConnected returns whether the client is connected.
+func (c *PubSubClient) IsConnected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ws != nil && c.ws.IsConnected()
+}
+
+// Topics returns the list of topics currently being listened to.
+func (c *PubSubClient) Topics() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	topics := make([]string, 0, len(c.topics))
+	for topic := range c.topics {
+		topics = append(topics, topic)
+	}
+	return topics
+}
+
+// SessionID returns the EventSub session ID.
+func (c *PubSubClient) SessionID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sessionID
+}
+
+// handleNotification routes EventSub notifications to the appropriate topic handler.
+func (c *PubSubClient) handleNotification(sub *EventSubSubscription, event json.RawMessage) {
+	c.mu.RLock()
+	topic, exists := c.subToTopic[sub.ID]
+	handler := c.onMessage
+	c.mu.RUnlock()
+
+	if !exists || handler == nil {
+		return
+	}
+
+	// Wrap event in a PubSub-style message envelope
+	message := PubSubMessage{
+		Type: sub.Type,
+		Data: event,
+	}
+
+	msgJSON, err := json.Marshal(message)
+	if err != nil {
+		if c.onError != nil {
+			c.onError(fmt.Errorf("marshaling message: %w", err))
+		}
+		return
+	}
+
+	handler(topic, msgJSON)
+}
+
+// handleRevocation handles subscription revocations.
+func (c *PubSubClient) handleRevocation(sub *EventSubSubscription) {
+	c.mu.Lock()
+	topic, exists := c.subToTopic[sub.ID]
+	if exists {
+		delete(c.subToTopic, sub.ID)
+		// Remove from topics list
+		if subIDs, ok := c.topics[topic]; ok {
+			for i, id := range subIDs {
+				if id == sub.ID {
+					c.topics[topic] = append(subIDs[:i], subIDs[i+1:]...)
+					break
+				}
+			}
+			if len(c.topics[topic]) == 0 {
+				delete(c.topics, topic)
+			}
+		}
+	}
+	c.mu.Unlock()
+
+	if c.onError != nil {
+		c.onError(fmt.Errorf("subscription revoked: %s (topic: %s, reason: %s)",
+			sub.ID, topic, sub.Status))
+	}
+}
+
+// handleReconnect handles WebSocket reconnection requests.
+func (c *PubSubClient) handleReconnect(reconnectURL string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		newSessionID, err := c.ws.Reconnect(ctx, reconnectURL)
+		if err != nil {
+			if c.onError != nil {
+				c.onError(fmt.Errorf("reconnecting: %w", err))
+			}
+			return
+		}
+
+		c.mu.Lock()
+		c.sessionID = newSessionID
+		c.mu.Unlock()
+
+		if c.onReconnect != nil {
+			c.onReconnect()
+		}
+	}()
+}
+
+// handleError routes errors to the error handler.
+func (c *PubSubClient) handleError(err error) {
+	if c.onError != nil {
+		c.onError(err)
+	}
+}
+
+// SupportedTopics returns a list of supported PubSub topic patterns.
+func SupportedTopics() []string {
+	return []string{
+		"channel-bits-events-v1.<channel_id>",
+		"channel-bits-events-v2.<channel_id>",
+		"channel-bits-badge-unlocks.<channel_id>",
+		"channel-points-channel-v1.<channel_id>",
+		"channel-subscribe-events-v1.<channel_id>",
+		"automod-queue.<moderator_id>.<channel_id>",
+		"chat_moderator_actions.<user_id>.<channel_id>",
+		"whispers.<user_id>",
+	}
+}
+
+// TopicEventSubTypes returns the EventSub types that a PubSub topic maps to.
+// Returns nil if the topic is invalid or unsupported.
+func TopicEventSubTypes(topic string) []string {
+	parsed, err := ParseTopic(topic)
+	if err != nil {
+		return nil
+	}
+
+	mapping, exists := topicMappings[parsed.Type]
+	if !exists {
+		return nil
+	}
+
+	return mapping.EventSubTypes
+}
+
+// BuildTopic constructs a PubSub topic string from components.
+// This is a helper for users migrating from PubSub who need to construct topics.
+func BuildTopic(topicType string, ids ...string) string {
+	switch topicType {
+	case "channel-bits-events-v1", "channel-bits-events-v2":
+		if len(ids) >= 1 {
+			return topicType + "." + ids[0]
+		}
+	case "channel-bits-badge-unlocks", "channel-points-channel-v1", "channel-subscribe-events-v1":
+		if len(ids) >= 1 {
+			return topicType + "." + ids[0]
+		}
+	case "automod-queue":
+		if len(ids) >= 2 {
+			return "automod-queue." + ids[0] + "." + ids[1]
+		}
+	case "chat_moderator_actions":
+		if len(ids) >= 2 {
+			return "chat_moderator_actions." + ids[0] + "." + ids[1]
+		}
+	case "whispers":
+		if len(ids) >= 1 {
+			return "whispers." + ids[0]
+		}
+	}
+	return ""
+}
+

--- a/helix/pubsub_compat_test.go
+++ b/helix/pubsub_compat_test.go
@@ -1,0 +1,830 @@
+package helix
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestParseTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topic     string
+		wantType  string
+		wantChan  string
+		wantUser  string
+		wantMod   string
+		wantError bool
+	}{
+		{
+			name:     "channel-bits-events-v1",
+			topic:    "channel-bits-events-v1.12345",
+			wantType: "channel-bits-events",
+			wantChan: "12345",
+		},
+		{
+			name:     "channel-bits-events-v2",
+			topic:    "channel-bits-events-v2.67890",
+			wantType: "channel-bits-events",
+			wantChan: "67890",
+		},
+		{
+			name:     "channel-bits-badge-unlocks",
+			topic:    "channel-bits-badge-unlocks.12345",
+			wantType: "channel-bits-badge",
+			wantChan: "12345",
+		},
+		{
+			name:     "channel-points-channel-v1",
+			topic:    "channel-points-channel-v1.12345",
+			wantType: "channel-points-channel",
+			wantChan: "12345",
+		},
+		{
+			name:     "channel-subscribe-events-v1",
+			topic:    "channel-subscribe-events-v1.12345",
+			wantType: "channel-subscribe",
+			wantChan: "12345",
+		},
+		{
+			name:     "automod-queue",
+			topic:    "automod-queue.11111.22222",
+			wantType: "automod-queue",
+			wantMod:  "11111",
+			wantChan: "22222",
+		},
+		{
+			name:     "chat_moderator_actions",
+			topic:    "chat_moderator_actions.11111.22222",
+			wantType: "chat-moderator-actions",
+			wantUser: "11111",
+			wantChan: "22222",
+		},
+		{
+			name:     "whispers",
+			topic:    "whispers.12345",
+			wantType: "whispers",
+			wantUser: "12345",
+		},
+		{
+			name:      "invalid topic",
+			topic:     "invalid-topic.123",
+			wantError: true,
+		},
+		{
+			name:      "empty topic",
+			topic:     "",
+			wantError: true,
+		},
+		{
+			name:      "missing channel id",
+			topic:     "channel-bits-events-v1.",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseTopic(tt.topic)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if parsed.Type != tt.wantType {
+				t.Errorf("Type: expected %q, got %q", tt.wantType, parsed.Type)
+			}
+			if parsed.ChannelID != tt.wantChan {
+				t.Errorf("ChannelID: expected %q, got %q", tt.wantChan, parsed.ChannelID)
+			}
+			if parsed.UserID != tt.wantUser {
+				t.Errorf("UserID: expected %q, got %q", tt.wantUser, parsed.UserID)
+			}
+			if parsed.ModeratorID != tt.wantMod {
+				t.Errorf("ModeratorID: expected %q, got %q", tt.wantMod, parsed.ModeratorID)
+			}
+		})
+	}
+}
+
+func TestTopicEventSubTypes(t *testing.T) {
+	tests := []struct {
+		topic    string
+		expected []string
+	}{
+		{
+			topic:    "channel-bits-events-v1.12345",
+			expected: []string{EventSubTypeChannelCheer},
+		},
+		{
+			topic:    "channel-points-channel-v1.12345",
+			expected: []string{EventSubTypeChannelPointsRedemptionAdd},
+		},
+		{
+			topic: "channel-subscribe-events-v1.12345",
+			expected: []string{
+				EventSubTypeChannelSubscribe,
+				EventSubTypeChannelSubscriptionGift,
+				EventSubTypeChannelSubscriptionMessage,
+			},
+		},
+		{
+			topic:    "whispers.12345",
+			expected: []string{EventSubTypeUserWhisperMessage},
+		},
+		{
+			topic:    "invalid-topic",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.topic, func(t *testing.T) {
+			result := TopicEventSubTypes(tt.topic)
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d types, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, typ := range tt.expected {
+				if result[i] != typ {
+					t.Errorf("index %d: expected %q, got %q", i, typ, result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicType string
+		ids       []string
+		expected  string
+	}{
+		{
+			name:      "channel-bits-events-v1",
+			topicType: "channel-bits-events-v1",
+			ids:       []string{"12345"},
+			expected:  "channel-bits-events-v1.12345",
+		},
+		{
+			name:      "channel-bits-events-v2",
+			topicType: "channel-bits-events-v2",
+			ids:       []string{"12345"},
+			expected:  "channel-bits-events-v2.12345",
+		},
+		{
+			name:      "channel-points-channel-v1",
+			topicType: "channel-points-channel-v1",
+			ids:       []string{"12345"},
+			expected:  "channel-points-channel-v1.12345",
+		},
+		{
+			name:      "automod-queue",
+			topicType: "automod-queue",
+			ids:       []string{"11111", "22222"},
+			expected:  "automod-queue.11111.22222",
+		},
+		{
+			name:      "chat_moderator_actions",
+			topicType: "chat_moderator_actions",
+			ids:       []string{"11111", "22222"},
+			expected:  "chat_moderator_actions.11111.22222",
+		},
+		{
+			name:      "whispers",
+			topicType: "whispers",
+			ids:       []string{"12345"},
+			expected:  "whispers.12345",
+		},
+		{
+			name:      "unknown type",
+			topicType: "unknown",
+			ids:       []string{"12345"},
+			expected:  "",
+		},
+		{
+			name:      "missing ids",
+			topicType: "channel-bits-events-v1",
+			ids:       []string{},
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildTopic(tt.topicType, tt.ids...)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSupportedTopics(t *testing.T) {
+	topics := SupportedTopics()
+	if len(topics) == 0 {
+		t.Error("expected at least one supported topic")
+	}
+
+	// Verify expected topics are present
+	expectedPatterns := []string{
+		"channel-bits-events-v1",
+		"channel-points-channel-v1",
+		"whispers",
+	}
+
+	for _, pattern := range expectedPatterns {
+		found := false
+		for _, topic := range topics {
+			if strings.Contains(topic, pattern) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected pattern %q to be in supported topics", pattern)
+		}
+	}
+}
+
+func TestNewPubSubClient(t *testing.T) {
+	client := &Client{} // Mock client
+	pubsub := NewPubSubClient(client)
+
+	if pubsub == nil {
+		t.Fatal("expected non-nil PubSubClient")
+	}
+	if pubsub.client != client {
+		t.Error("client not set correctly")
+	}
+	if pubsub.topics == nil {
+		t.Error("topics map not initialized")
+	}
+	if pubsub.subToTopic == nil {
+		t.Error("subToTopic map not initialized")
+	}
+}
+
+func TestNewPubSubClient_WithOptions(t *testing.T) {
+	client := &Client{}
+	customURL := "wss://custom.example.com/ws"
+	messageCalled := false
+	errorCalled := false
+	connectCalled := false
+	reconnectCalled := false
+
+	pubsub := NewPubSubClient(client,
+		WithPubSubWSURL(customURL),
+		WithPubSubMessageHandler(func(topic string, msg json.RawMessage) {
+			messageCalled = true
+		}),
+		WithPubSubErrorHandler(func(err error) {
+			errorCalled = true
+		}),
+		WithPubSubConnectHandler(func() {
+			connectCalled = true
+		}),
+		WithPubSubReconnectHandler(func() {
+			reconnectCalled = true
+		}),
+	)
+
+	if pubsub.wsURL != customURL {
+		t.Errorf("expected wsURL %q, got %q", customURL, pubsub.wsURL)
+	}
+
+	// Test handlers are set
+	if pubsub.onMessage != nil {
+		pubsub.onMessage("test", nil)
+	}
+	if pubsub.onError != nil {
+		pubsub.onError(nil)
+	}
+	if pubsub.onConnect != nil {
+		pubsub.onConnect()
+	}
+	if pubsub.onReconnect != nil {
+		pubsub.onReconnect()
+	}
+
+	if !messageCalled || !errorCalled || !connectCalled || !reconnectCalled {
+		t.Error("not all handlers were called")
+	}
+}
+
+func TestPubSubClient_IsConnected(t *testing.T) {
+	client := &Client{}
+	pubsub := NewPubSubClient(client)
+
+	if pubsub.IsConnected() {
+		t.Error("expected not connected before Connect()")
+	}
+}
+
+func TestPubSubClient_Topics(t *testing.T) {
+	client := &Client{}
+	pubsub := NewPubSubClient(client)
+
+	topics := pubsub.Topics()
+	if len(topics) != 0 {
+		t.Errorf("expected 0 topics, got %d", len(topics))
+	}
+}
+
+func TestPubSubClient_ListenNotConnected(t *testing.T) {
+	client := &Client{}
+	pubsub := NewPubSubClient(client)
+
+	err := pubsub.Listen(context.Background(), "channel-bits-events-v1.12345")
+	if err != ErrPubSubNotConnected {
+		t.Errorf("expected ErrPubSubNotConnected, got %v", err)
+	}
+}
+
+// mockPubSubWSServer creates a test WebSocket server for PubSub testing
+type mockPubSubWSServer struct {
+	server   *httptest.Server
+	upgrader websocket.Upgrader
+	conn     *websocket.Conn
+	mu       sync.Mutex
+}
+
+func newMockPubSubWSServer(handler func(*websocket.Conn)) *mockPubSubWSServer {
+	mock := &mockPubSubWSServer{
+		upgrader: websocket.Upgrader{},
+	}
+
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := mock.upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		mock.mu.Lock()
+		mock.conn = conn
+		mock.mu.Unlock()
+		handler(conn)
+	}))
+
+	return mock
+}
+
+func (m *mockPubSubWSServer) URL() string {
+	return "ws" + strings.TrimPrefix(m.server.URL, "http")
+}
+
+func (m *mockPubSubWSServer) Close() {
+	m.mu.Lock()
+	if m.conn != nil {
+		_ = m.conn.Close()
+	}
+	m.mu.Unlock()
+	m.server.Close()
+}
+
+// mockHelixServer creates a mock Helix API server for subscription management
+type mockHelixServer struct {
+	server        *httptest.Server
+	subscriptions map[string]*EventSubSubscription
+	mu            sync.Mutex
+	subIDCounter  int
+}
+
+func newMockHelixServer() *mockHelixServer {
+	mock := &mockHelixServer{
+		subscriptions: make(map[string]*EventSubSubscription),
+	}
+
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			// Create subscription
+			var params CreateEventSubSubscriptionParams
+			if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			mock.mu.Lock()
+			mock.subIDCounter++
+			subID := "sub-" + string(rune('0'+mock.subIDCounter))
+			sub := &EventSubSubscription{
+				ID:        subID,
+				Status:    EventSubStatusEnabled,
+				Type:      params.Type,
+				Version:   params.Version,
+				Condition: params.Condition,
+				Transport: EventSubTransport{
+					Method:    params.Transport.Method,
+					SessionID: params.Transport.SessionID,
+				},
+			}
+			mock.subscriptions[subID] = sub
+			mock.mu.Unlock()
+
+			resp := EventSubResponse{
+				Data:  []EventSubSubscription{*sub},
+				Total: 1,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case http.MethodDelete:
+			// Delete subscription
+			subID := r.URL.Query().Get("id")
+			mock.mu.Lock()
+			delete(mock.subscriptions, subID)
+			mock.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+
+	return mock
+}
+
+func (m *mockHelixServer) Close() {
+	m.server.Close()
+}
+
+func TestPubSubClient_Connect(t *testing.T) {
+	sessionID := "pubsub-session-123"
+
+	wsMock := newMockPubSubWSServer(func(conn *websocket.Conn) {
+		// Send welcome message
+		welcome := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "welcome-1",
+				MessageType:      WSMessageTypeWelcome,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketWelcomePayload{
+				Session: WebSocketSession{
+					ID:                      sessionID,
+					Status:                  "connected",
+					ConnectedAt:             time.Now(),
+					KeepaliveTimeoutSeconds: 10,
+				},
+			}),
+		}
+		_ = conn.WriteJSON(welcome)
+		time.Sleep(100 * time.Millisecond)
+	})
+	defer wsMock.Close()
+
+	helixMock := newMockHelixServer()
+	defer helixMock.Close()
+
+	helixClient := NewClient("test-client-id", nil)
+	helixClient.baseURL = helixMock.server.URL
+
+	connectCalled := false
+	pubsub := NewPubSubClient(helixClient,
+		WithPubSubWSURL(wsMock.URL()),
+		WithPubSubConnectHandler(func() {
+			connectCalled = true
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pubsub.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	if !pubsub.IsConnected() {
+		t.Error("expected to be connected")
+	}
+
+	if pubsub.SessionID() != sessionID {
+		t.Errorf("expected session ID %q, got %q", sessionID, pubsub.SessionID())
+	}
+
+	if !connectCalled {
+		t.Error("connect handler was not called")
+	}
+
+	// Test Close
+	err = pubsub.Close(ctx)
+	if err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+}
+
+func TestPubSubClient_ListenAndUnlisten(t *testing.T) {
+	sessionID := "pubsub-session-listen"
+
+	wsMock := newMockPubSubWSServer(func(conn *websocket.Conn) {
+		welcome := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "welcome-1",
+				MessageType:      WSMessageTypeWelcome,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketWelcomePayload{
+				Session: WebSocketSession{
+					ID:                      sessionID,
+					Status:                  "connected",
+					ConnectedAt:             time.Now(),
+					KeepaliveTimeoutSeconds: 10,
+				},
+			}),
+		}
+		_ = conn.WriteJSON(welcome)
+		time.Sleep(500 * time.Millisecond)
+	})
+	defer wsMock.Close()
+
+	helixMock := newMockHelixServer()
+	defer helixMock.Close()
+
+	helixClient := NewClient("test-client-id", nil)
+	helixClient.baseURL = helixMock.server.URL
+
+	pubsub := NewPubSubClient(helixClient, WithPubSubWSURL(wsMock.URL()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pubsub.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer func() { _ = pubsub.Close(ctx) }()
+
+	// Listen to a topic
+	topic := "channel-points-channel-v1.12345"
+	err = pubsub.Listen(ctx, topic)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+
+	// Verify topic is tracked
+	topics := pubsub.Topics()
+	if len(topics) != 1 {
+		t.Errorf("expected 1 topic, got %d", len(topics))
+	}
+	if topics[0] != topic {
+		t.Errorf("expected topic %q, got %q", topic, topics[0])
+	}
+
+	// Listen again should be idempotent
+	err = pubsub.Listen(ctx, topic)
+	if err != nil {
+		t.Fatalf("Second Listen failed: %v", err)
+	}
+	if len(pubsub.Topics()) != 1 {
+		t.Error("duplicate listen should not add topic")
+	}
+
+	// Unlisten
+	err = pubsub.Unlisten(ctx, topic)
+	if err != nil {
+		t.Fatalf("Unlisten failed: %v", err)
+	}
+
+	if len(pubsub.Topics()) != 0 {
+		t.Error("expected 0 topics after unlisten")
+	}
+
+	// Unlisten again should be safe
+	err = pubsub.Unlisten(ctx, topic)
+	if err != nil {
+		t.Fatalf("Second Unlisten failed: %v", err)
+	}
+}
+
+func TestPubSubClient_ListenInvalidTopic(t *testing.T) {
+	sessionID := "pubsub-session-invalid"
+
+	wsMock := newMockPubSubWSServer(func(conn *websocket.Conn) {
+		welcome := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "welcome-1",
+				MessageType:      WSMessageTypeWelcome,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketWelcomePayload{
+				Session: WebSocketSession{
+					ID:                      sessionID,
+					Status:                  "connected",
+					ConnectedAt:             time.Now(),
+					KeepaliveTimeoutSeconds: 10,
+				},
+			}),
+		}
+		_ = conn.WriteJSON(welcome)
+		time.Sleep(100 * time.Millisecond)
+	})
+	defer wsMock.Close()
+
+	helixClient := NewClient("test-client-id", nil)
+	pubsub := NewPubSubClient(helixClient, WithPubSubWSURL(wsMock.URL()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pubsub.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer func() { _ = pubsub.Close(ctx) }()
+
+	// Listen to invalid topic
+	err = pubsub.Listen(ctx, "invalid-topic-format")
+	if err == nil {
+		t.Error("expected error for invalid topic")
+	}
+}
+
+func TestPubSubClient_MultipleSubscriptionsPerTopic(t *testing.T) {
+	sessionID := "pubsub-session-multi"
+
+	wsMock := newMockPubSubWSServer(func(conn *websocket.Conn) {
+		welcome := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "welcome-1",
+				MessageType:      WSMessageTypeWelcome,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketWelcomePayload{
+				Session: WebSocketSession{
+					ID:                      sessionID,
+					Status:                  "connected",
+					ConnectedAt:             time.Now(),
+					KeepaliveTimeoutSeconds: 10,
+				},
+			}),
+		}
+		_ = conn.WriteJSON(welcome)
+		time.Sleep(500 * time.Millisecond)
+	})
+	defer wsMock.Close()
+
+	helixMock := newMockHelixServer()
+	defer helixMock.Close()
+
+	helixClient := NewClient("test-client-id", nil)
+	helixClient.baseURL = helixMock.server.URL
+
+	pubsub := NewPubSubClient(helixClient, WithPubSubWSURL(wsMock.URL()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pubsub.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer func() { _ = pubsub.Close(ctx) }()
+
+	// Listen to subscribe topic (maps to 3 EventSub types)
+	topic := "channel-subscribe-events-v1.12345"
+	err = pubsub.Listen(ctx, topic)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+
+	// Verify 3 subscriptions were created
+	helixMock.mu.Lock()
+	subCount := len(helixMock.subscriptions)
+	helixMock.mu.Unlock()
+
+	if subCount != 3 {
+		t.Errorf("expected 3 subscriptions, got %d", subCount)
+	}
+}
+
+func TestPubSubClient_NotificationRouting(t *testing.T) {
+	sessionID := "pubsub-session-notif"
+	var receivedTopic string
+	var receivedMessage json.RawMessage
+	notifReceived := make(chan struct{})
+
+	wsMock := newMockPubSubWSServer(func(conn *websocket.Conn) {
+		welcome := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "welcome-1",
+				MessageType:      WSMessageTypeWelcome,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketWelcomePayload{
+				Session: WebSocketSession{
+					ID:                      sessionID,
+					Status:                  "connected",
+					ConnectedAt:             time.Now(),
+					KeepaliveTimeoutSeconds: 10,
+				},
+			}),
+		}
+		_ = conn.WriteJSON(welcome)
+
+		// Wait a bit then send notification
+		time.Sleep(100 * time.Millisecond)
+
+		// Send notification with subscription ID that matches what we'll create
+		notification := WebSocketMessage{
+			Metadata: WebSocketMetadata{
+				MessageID:        "notif-1",
+				MessageType:      WSMessageTypeNotification,
+				MessageTimestamp: time.Now(),
+			},
+			Payload: mustMarshal(WebSocketNotificationPayload{
+				Subscription: EventSubSubscription{
+					ID:   "sub-1", // First subscription ID from mock server
+					Type: EventSubTypeChannelPointsRedemptionAdd,
+				},
+				Event: mustMarshal(map[string]string{
+					"user_name": "testuser",
+					"reward":    "Test Reward",
+				}),
+			}),
+		}
+		_ = conn.WriteJSON(notification)
+
+		time.Sleep(200 * time.Millisecond)
+	})
+	defer wsMock.Close()
+
+	helixMock := newMockHelixServer()
+	defer helixMock.Close()
+
+	helixClient := NewClient("test-client-id", nil)
+	helixClient.baseURL = helixMock.server.URL
+
+	pubsub := NewPubSubClient(helixClient,
+		WithPubSubWSURL(wsMock.URL()),
+		WithPubSubMessageHandler(func(topic string, msg json.RawMessage) {
+			receivedTopic = topic
+			receivedMessage = msg
+			close(notifReceived)
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pubsub.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer func() { _ = pubsub.Close(ctx) }()
+
+	topic := "channel-points-channel-v1.12345"
+	err = pubsub.Listen(ctx, topic)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+
+	// Wait for notification
+	select {
+	case <-notifReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for notification")
+	}
+
+	if receivedTopic != topic {
+		t.Errorf("expected topic %q, got %q", topic, receivedTopic)
+	}
+
+	if receivedMessage == nil {
+		t.Error("expected message to be non-nil")
+	}
+
+	// Verify message envelope
+	var envelope PubSubMessage
+	if err := json.Unmarshal(receivedMessage, &envelope); err != nil {
+		t.Fatalf("failed to parse message envelope: %v", err)
+	}
+
+	if envelope.Type != EventSubTypeChannelPointsRedemptionAdd {
+		t.Errorf("expected type %q, got %q", EventSubTypeChannelPointsRedemptionAdd, envelope.Type)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a PubSub compatibility layer that provides familiar `Listen(topic)`/`Unlisten(topic)` semantics while internally using EventSub WebSocket
- Enables smooth migration for developers transitioning from the deprecated Twitch PubSub system (decommissioned April 2025)
- Includes comprehensive documentation and examples

## Supported Topics

| PubSub Topic | EventSub Type(s) |
|--------------|------------------|
| `channel-bits-events-v1.<id>` | `channel.cheer` |
| `channel-bits-events-v2.<id>` | `channel.cheer` |
| `channel-bits-badge-unlocks.<id>` | `channel.chat.notification` |
| `channel-points-channel-v1.<id>` | `channel.channel_points_custom_reward_redemption.add` |
| `channel-subscribe-events-v1.<id>` | `channel.subscribe`, `channel.subscription.gift`, `channel.subscription.message` |
| `automod-queue.<mod>.<ch>` | `automod.message.hold` |
| `chat_moderator_actions.<user>.<ch>` | `channel.moderate` |
| `whispers.<id>` | `user.whisper.message` |

## Files Changed

- `helix/pubsub_compat.go` - Main implementation (~550 lines)
- `helix/pubsub_compat_test.go` - Unit tests (~550 lines)
- `docs/pubsub-compat.md` - API documentation
- `docs/examples/pubsub-migration.md` - Migration example
- Updated README.md, docs/README.md, ENDPOINTS.md

## Test plan

- [x] All existing tests pass
- [x] New PubSub tests pass (19 tests covering topic parsing, connection, listen/unlisten, event routing)
- [ ] Manual testing with live Twitch events