### PR TITLE
Fix changelog monitor workflow and bump action versions

### DIFF
--- a/.github/workflows/monitor-twitch-changelog.yml
+++ b/.github/workflows/monitor-twitch-changelog.yml
@@ -8,13 +8,14 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for changelog updates
         env:
@@ -91,9 +92,20 @@ jobs:
           # Update the stored hash
           echo "$NEW_HASH" > "$HASH_FILE"
 
-          # Commit the updated hash
+          # Commit the updated hash on a new branch and open an auto-merge PR
+          # (direct push to main is blocked by branch protection rules)
+          BRANCH="chore/twitch-changelog-hash-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add "$HASH_FILE"
           git commit -m "Update Twitch changelog hash"
-          git push
+          git push -u origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --title "chore: update Twitch changelog hash" \
+            --body "Automated hash update after detecting a Twitch changelog change. See the linked changelog issue for review details." \
+            --base main \
+            --head "$BRANCH")
+
+          gh pr merge "$PR_URL" --auto --squash --delete-branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 


### PR DESCRIPTION
## Summary

- Switch the Twitch changelog monitor from direct push to PR + auto-merge. Branch protection on `main` rejected the bot's direct push (failed run [24788478356](https://github.com/Its-donkey/kappopher/actions/runs/24788478356)). The workflow now creates a short-lived `chore/twitch-changelog-hash-<timestamp>` branch, opens a PR, and enables auto-merge + delete-branch.
- Bump `actions/checkout@v4` → `@v6` and `actions/setup-go@v5` → `@v6` in `test.yml` and `monitor-twitch-changelog.yml` to match the release workflows and clear the Node.js 20 deprecation warning.
- Add `pull-requests: write` permission to the monitor workflow so it can open the hash-update PR.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, manually trigger `monitor-twitch-changelog.yml` via `gh workflow run` and confirm:
  - [ ] A hash-update PR is opened against `main`
  - [ ] Auto-merge is enabled on it
  - [ ] It merges once required checks pass and the branch is deleted

Related: issue #62 (the first successful changelog issue, created by the workflow before the push failure).