### PR TITLE
Add CHANGELOG entry for workflow state-branch migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- CI: moved Twitch changelog monitor state to a dedicated `state/twitch-changelog` orphan branch so the bot no longer fights `main` branch protection, and bumped `actions/checkout` and `actions/setup-go` to v6
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Adds a CHANGELOG entry under `[Unreleased]` → `### Changed` documenting the workflow migration that merged in #64. Without this, `Promote Release` fails the "no unreleased changes" check (see [run 24831823132](https://github.com/Its-donkey/kappopher/actions/runs/24831823132)).

## Test plan

- [x] Merge this into `test`
- [x] Promote `test` → `main`
- [x] Retry `Promote Release` workflow for v1.2.1 — it should now pass the CHANGELOG check