### PR TITLE
Require CHANGELOG.md update on PRs to test

### DIFF
--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -1,0 +1,53 @@
+name: Require CHANGELOG Update
+
+on:
+  pull_request:
+    branches: [test]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Minimal permissions — only needs to read the PR diff and labels
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for skip-changelog label
+        id: label
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q '"skip-changelog"'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::'skip-changelog' label present — CHANGELOG check skipped"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR
+        if: steps.label.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify CHANGELOG.md was modified
+        if: steps.label.outputs.skip != 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          if git diff --name-only "origin/$BASE_REF...HEAD" | grep -qx 'CHANGELOG\.md'; then
+            echo "✅ CHANGELOG.md was updated"
+          else
+            echo "❌ CHANGELOG.md must be updated for PRs to $BASE_REF"
+            echo ""
+            echo "Add an entry under [Unreleased] in CHANGELOG.md describing your change."
+            echo ""
+            echo "If this PR genuinely doesn't need a CHANGELOG entry (docs typo,"
+            echo "internal refactor with no user-visible effect, test-only change),"
+            echo "add the 'skip-changelog' label to this PR."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CI: `Require CHANGELOG Update` workflow that fails PRs to `test` when `CHANGELOG.md` is not modified (override with a `skip-changelog` label for docs-only or internal changes)
 
 ### Changed
 - CI: moved Twitch changelog monitor state to a dedicated `state/twitch-changelog` orphan branch so the bot no longer fights `main` branch protection, and bumped `actions/checkout` and `actions/setup-go` to v6


### PR DESCRIPTION
## Summary

Adds a CI check that fails PRs to `test` when `CHANGELOG.md` is not modified, so we never again merge a change that later blocks `Promote Release` (see [run 24831823132](https://github.com/Its-donkey/kappopher/actions/runs/24831823132)).

- New workflow: `.github/workflows/require-changelog.yml`
- Runs on PRs to `test` (every PR funnels through `test` per promotion policy, so this is sufficient)
- Escape hatch: `skip-changelog` label bypasses the check for docs-only, test-only, or internal refactors with no user-visible effect
- CHANGELOG entry added for the new workflow itself

## Test plan

- [ ] This PR passes its own check (it modifies CHANGELOG.md — meta)
- [ ] After merge + promotion, open a trivial PR without touching CHANGELOG → check fails
- [ ] Apply `skip-changelog` label to that PR → check re-runs and passes