### PR TITLE
Correct ChannelBitsUseEvent to match channel.bits.use payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **BREAKING:** Corrected `ChannelBitsUseEvent` to match the `channel.bits.use` payload: `BitsUsed` JSON tag fixed (`bits_used` → `bits`), removed the non-existent `UsedAt` field, changed `Message` from `*string` to `*ChatEventMessage` (the documented `{text, fragments[]}` object), and added `CustomPowerUp`. `PowerUp`/`CustomPowerUp` are `*json.RawMessage` since Twitch does not document their object fields. Removed the unused `PowerUp` type.
 
 ## [1.2.2] - 2026-04-23 ([#75](https://github.com/Its-donkey/kappopher/pull/75))
 

--- a/helix/eventsub_events.go
+++ b/helix/eventsub_events.go
@@ -718,16 +718,14 @@ type ChannelAdBreakBeginEvent struct {
 type ChannelBitsUseEvent struct {
 	EventSubBroadcaster
 	EventSubUser
-	BitsUsed int       `json:"bits_used"`
-	Type     string    `json:"type"` // cheer, power_up_celebration, power_up_gigantify, power_up_message_effect
-	UsedAt   time.Time `json:"used_at"`
-	Message  *string   `json:"message,omitempty"`
-	PowerUp  *PowerUp  `json:"power_up,omitempty"`
-}
-
-// PowerUp represents a bits power-up.
-type PowerUp struct {
-	Type string `json:"type"`
+	BitsUsed int               `json:"bits"`
+	Type     string            `json:"type"` // e.g. "cheer"
+	Message  *ChatEventMessage `json:"message,omitempty"`
+	// PowerUp and CustomPowerUp are null unless a Power-up is used. Twitch does
+	// not document their object fields, so they are kept as raw JSON to avoid
+	// asserting an unverified schema.
+	PowerUp       *json.RawMessage `json:"power_up,omitempty"`
+	CustomPowerUp *json.RawMessage `json:"custom_power_up,omitempty"`
 }
 
 // VIP Events

--- a/helix/eventsub_events_test.go
+++ b/helix/eventsub_events_test.go
@@ -8,6 +8,70 @@ import (
 // Tests for eventsub_events.go event types using official Twitch API documentation payloads.
 // Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/
 
+// TestChannelBitsUseEvent_OfficialPayload unmarshals the official channel.bits.use
+// event payload and verifies the message object, fragments, and null power-ups.
+func TestChannelBitsUseEvent_OfficialPayload(t *testing.T) {
+	// Official Twitch example event object for channel.bits.use.
+	payload := []byte(`{
+		"user_id": "1234",
+		"user_login": "cool_user",
+		"user_name": "Cool_User",
+		"broadcaster_user_id": "1337",
+		"broadcaster_user_login": "cooler_user",
+		"broadcaster_user_name": "Cooler_User",
+		"bits": 2,
+		"type": "cheer",
+		"power_up": null,
+		"custom_power_up": null,
+		"message": {
+			"text": "cheer1 hi cheer1",
+			"fragments": [
+				{"type": "cheermote", "text": "cheer1", "cheermote": {"prefix": "cheer", "bits": 1, "tier": 1}, "emote": null},
+				{"type": "text", "text": " hi ", "cheermote": null, "emote": null},
+				{"type": "cheermote", "text": "cheer1", "cheermote": {"prefix": "cheer", "bits": 1, "tier": 1}, "emote": null}
+			]
+		}
+	}`)
+
+	var event ChannelBitsUseEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if event.UserID != "1234" || event.BroadcasterUserID != "1337" {
+		t.Errorf("embedded user/broadcaster not decoded: %+v", event)
+	}
+	if event.BitsUsed != 2 {
+		t.Errorf("BitsUsed = %d, want 2", event.BitsUsed)
+	}
+	if event.Type != "cheer" {
+		t.Errorf("Type = %q, want cheer", event.Type)
+	}
+	// power_up and custom_power_up are null -> nil.
+	if event.PowerUp != nil {
+		t.Errorf("PowerUp = %s, want nil", *event.PowerUp)
+	}
+	if event.CustomPowerUp != nil {
+		t.Errorf("CustomPowerUp = %s, want nil", *event.CustomPowerUp)
+	}
+	if event.Message == nil {
+		t.Fatal("Message is nil, want decoded object")
+	}
+	if event.Message.Text != "cheer1 hi cheer1" {
+		t.Errorf("Message.Text = %q", event.Message.Text)
+	}
+	if len(event.Message.Fragments) != 3 {
+		t.Fatalf("Fragments len = %d, want 3", len(event.Message.Fragments))
+	}
+	frag := event.Message.Fragments[0]
+	if frag.Type != "cheermote" || frag.Cheermote == nil {
+		t.Fatalf("fragment[0] = %+v, want cheermote", frag)
+	}
+	if frag.Cheermote.Prefix != "cheer" || frag.Cheermote.Bits != 1 || frag.Cheermote.Tier != 1 {
+		t.Errorf("fragment[0].Cheermote = %+v", frag.Cheermote)
+	}
+}
+
 func TestHypeTrainBeginEvent_V1ToV2Conversion(t *testing.T) {
 	// Official Twitch v1 example from https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainbegin
 	// Modified is_golden_kappa_train to true for golden kappa test


### PR DESCRIPTION
## Description

Corrects `ChannelBitsUseEvent` to match the official `channel.bits.use` EventSub payload ([reference](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/)):

- `BitsUsed` JSON tag `bits_used` → `bits`
- Removed the non-existent `UsedAt` (`used_at`) field
- `Message` changed from `*string` to `*ChatEventMessage` (the documented `{text, fragments[]}` object — reuses the existing chat fragment types)
- Added `CustomPowerUp`
- `PowerUp`/`CustomPowerUp` are `*json.RawMessage` (always `null` in samples; Twitch does not document their object fields, so raw avoids asserting an unverified schema)
- Removed the now-unused `PowerUp` type

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] Added `TestChannelBitsUseEvent_OfficialPayload` driven by Twitch's official example payload
- [x] `go build`, `go vet`, and the full suite pass