### PR TITLE
Correct suspicious-user endpoints to match Twitch reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `SuspiciousUserAction` and `SuspiciousUserType` types, and the `SuspiciousUserStatusActiveMonitoring`/`SuspiciousUserStatusNoTreatment` status constants
 
 ### Changed
 
 ### Fixed
+- **BREAKING:** Corrected the suspicious-user endpoints to match the Twitch reference: `SuspiciousUserStatus` values are now `ACTIVE_MONITORING`/`RESTRICTED` (was `monitored`/`restricted`); renamed `SuspiciousUserStatusMonitored` → `SuspiciousUserStatusActiveMonitoring`. `AddSuspiciousStatusToChatUser` and `RemoveSuspiciousStatusFromChatUser` now return `(*SuspiciousUserAction, error)` (the documented response with `updated_at`, `status`, and `types`) instead of discarding the response body.
 
 ## [1.2.2] - 2026-04-23 ([#75](https://github.com/Its-donkey/kappopher/pull/75))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **BREAKING:** Corrected the suspicious-user endpoints to match the Twitch reference: `SuspiciousUserStatus` values are now `ACTIVE_MONITORING`/`RESTRICTED` (was `monitored`/`restricted`); renamed `SuspiciousUserStatusMonitored` → `SuspiciousUserStatusActiveMonitoring`. `AddSuspiciousStatusToChatUser` and `RemoveSuspiciousStatusFromChatUser` now return `(*SuspiciousUserAction, error)` (the documented response with `updated_at`, `status`, and `types`) instead of discarding the response body.
-- **BREAKING:** Corrected `ChannelBitsUseEvent` to match the `channel.bits.use` payload: `BitsUsed` JSON tag fixed (`bits_used` → `bits`), removed the non-existent `UsedAt` field, changed `Message` from `*string` to `*ChatEventMessage` (the documented `{text, fragments[]}` object), and added `CustomPowerUp`. `PowerUp`/`CustomPowerUp` are `*json.RawMessage` since Twitch does not document their object fields. Removed the unused `PowerUp` type.
+- Corrected the suspicious-user endpoints to match the Twitch reference: `SuspiciousUserStatus` values are now `ACTIVE_MONITORING`/`RESTRICTED` (was `monitored`/`restricted`); renamed `SuspiciousUserStatusMonitored` → `SuspiciousUserStatusActiveMonitoring`. `AddSuspiciousStatusToChatUser` and `RemoveSuspiciousStatusFromChatUser` now return `(*SuspiciousUserAction, error)` (the documented response with `updated_at`, `status`, and `types`) instead of discarding the response body.
+- Corrected `ChannelBitsUseEvent` to match the `channel.bits.use` payload: `BitsUsed` JSON tag fixed (`bits_used` → `bits`), removed the non-existent `UsedAt` field, changed `Message` from `*string` to `*ChatEventMessage` (the documented `{text, fragments[]}` object), and added `CustomPowerUp`. `PowerUp`/`CustomPowerUp` are `*json.RawMessage` since Twitch does not document their object fields. Removed the unused `PowerUp` type.
 
 ## [1.2.2] - 2026-04-23 ([#75](https://github.com/Its-donkey/kappopher/pull/75))
 
@@ -42,12 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom `Pagination.UnmarshalJSON` to handle Twitch endpoints that return pagination as a string instead of an object (e.g. Get Extension Live Channels)
 
 ### Changed
-- **BREAKING:** Renamed `GetCustomRewards` → `GetCustomReward` (aligns with Twitch API reference)
-- **BREAKING:** Renamed `GetCustomRewardRedemptions` → `GetCustomRewardRedemption` (aligns with Twitch API reference)
-- **BREAKING:** Renamed `GetCharityDonations` → `GetCharityCampaignDonations` (aligns with Twitch API reference)
-- **BREAKING:** Renamed `AddSuspiciousUserStatus` → `AddSuspiciousStatusToChatUser` (aligns with Twitch API reference)
-- **BREAKING:** Renamed `RemoveSuspiciousUserStatus` → `RemoveSuspiciousStatusFromChatUser` (aligns with Twitch API reference)
-- **BREAKING:** `GetCharityCampaign` now takes `*GetCharityCampaignParams` instead of a bare `string`, and returns `*Response[CharityCampaign]` instead of `*CharityCampaign`
+- Renamed `GetCustomRewards` → `GetCustomReward` (aligns with Twitch API reference)
+- Renamed `GetCustomRewardRedemptions` → `GetCustomRewardRedemption` (aligns with Twitch API reference)
+- Renamed `GetCharityDonations` → `GetCharityCampaignDonations` (aligns with Twitch API reference)
+- Renamed `AddSuspiciousUserStatus` → `AddSuspiciousStatusToChatUser` (aligns with Twitch API reference)
+- Renamed `RemoveSuspiciousUserStatus` → `RemoveSuspiciousStatusFromChatUser` (aligns with Twitch API reference)
+- `GetCharityCampaign` now takes `*GetCharityCampaignParams` instead of a bare `string`, and returns `*Response[CharityCampaign]` instead of `*CharityCampaign`
 - All params types renamed to match their function names (`GetCustomRewardsParams` → `GetCustomRewardParams`, etc.)
 
 ### Fixed

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -787,54 +787,54 @@ for _, channel := range resp.Data {
 
 ## AddSuspiciousStatusToChatUser
 
-Add a suspicious status to a chat user. Suspicious users can be marked as "restricted" (cannot chat) or "monitored" (messages are flagged for review).
+Add a suspicious status to a chat user. Suspicious users can be marked as `ACTIVE_MONITORING` (messages are flagged for moderator review) or `RESTRICTED` (cannot chat). The applied status is returned.
 
 **Requires:** `moderator:manage:suspicious_users`
 
 ```go
 // Mark a user as restricted (cannot send messages)
-err := client.AddSuspiciousStatusToChatUser(ctx, &helix.AddSuspiciousStatusToChatUserParams{
+action, err := client.AddSuspiciousStatusToChatUser(ctx, &helix.AddSuspiciousStatusToChatUserParams{
     BroadcasterID: "12345",
     ModeratorID:   "67890",
     UserID:        "11111",
     Status:        helix.SuspiciousUserStatusRestricted,
 })
+if err != nil {
+    fmt.Printf("Failed to add suspicious user status: %v\n", err)
+    return
+}
+fmt.Printf("Status: %s, types: %v\n", action.Status, action.Types)
 
-// Mark a user as monitored (messages flagged for review)
-err = client.AddSuspiciousStatusToChatUser(ctx, &helix.AddSuspiciousStatusToChatUserParams{
+// Mark a user as active monitoring (messages flagged for review)
+action, err = client.AddSuspiciousStatusToChatUser(ctx, &helix.AddSuspiciousStatusToChatUserParams{
     BroadcasterID: "12345",
     ModeratorID:   "67890",
     UserID:        "22222",
-    Status:        helix.SuspiciousUserStatusMonitored,
+    Status:        helix.SuspiciousUserStatusActiveMonitoring,
 })
-
-if err != nil {
-    fmt.Printf("Failed to add suspicious user status: %v\n", err)
-}
 ```
 
 **Status Values:**
-- `helix.SuspiciousUserStatusRestricted` ("restricted") - User cannot send messages in chat
-- `helix.SuspiciousUserStatusMonitored` ("monitored") - User's messages are flagged for moderator review
+- `helix.SuspiciousUserStatusRestricted` ("RESTRICTED") - User cannot send messages in chat
+- `helix.SuspiciousUserStatusActiveMonitoring` ("ACTIVE_MONITORING") - User's messages are flagged for moderator review
 
-**Response:** This endpoint returns 204 No Content on success.
+**Response:** Returns a `*helix.SuspiciousUserAction` with the user's updated `Status` and the `Types` indicating how they were flagged (e.g. `MANUALLY_ADDED`, `DETECTED_BAN_EVADER`).
 
 ## RemoveSuspiciousStatusFromChatUser
 
-Remove a suspicious status from a chat user, allowing them to chat normally again.
+Remove a suspicious status from a chat user, allowing them to chat normally again. The resulting status (`NO_TREATMENT`) is returned.
 
 **Requires:** `moderator:manage:suspicious_users`
 
 ```go
-err := client.RemoveSuspiciousStatusFromChatUser(ctx, &helix.RemoveSuspiciousStatusFromChatUserParams{
+action, err := client.RemoveSuspiciousStatusFromChatUser(ctx, &helix.RemoveSuspiciousStatusFromChatUserParams{
     BroadcasterID: "12345",
     ModeratorID:   "67890",
     UserID:        "11111",
 })
-
 if err != nil {
     fmt.Printf("Failed to remove suspicious user status: %v\n", err)
 }
 ```
-**Response:** This endpoint returns 204 No Content on success.
+**Response:** Returns a `*helix.SuspiciousUserAction` with `Status` set to `NO_TREATMENT`.
 

--- a/helix/moderation.go
+++ b/helix/moderation.go
@@ -521,33 +521,64 @@ func (c *Client) GetModeratedChannels(ctx context.Context, params *GetModeratedC
 	return &resp, nil
 }
 
-// SuspiciousUserStatus represents the status of a suspicious user.
+// SuspiciousUserStatus represents the suspicious status applied to a user.
 type SuspiciousUserStatus string
 
 const (
+	// SuspiciousUserStatusActiveMonitoring indicates the user's activity is monitored.
+	SuspiciousUserStatusActiveMonitoring SuspiciousUserStatus = "ACTIVE_MONITORING"
 	// SuspiciousUserStatusRestricted indicates the user is restricted from chatting.
-	SuspiciousUserStatusRestricted SuspiciousUserStatus = "restricted"
-	// SuspiciousUserStatusMonitored indicates the user is being monitored.
-	SuspiciousUserStatusMonitored SuspiciousUserStatus = "monitored"
+	SuspiciousUserStatusRestricted SuspiciousUserStatus = "RESTRICTED"
+	// SuspiciousUserStatusNoTreatment is returned after a suspicious status is removed.
+	SuspiciousUserStatusNoTreatment SuspiciousUserStatus = "NO_TREATMENT"
 )
+
+// SuspiciousUserType represents how a user came to be flagged as suspicious.
+type SuspiciousUserType string
+
+const (
+	SuspiciousUserTypeManuallyAdded         SuspiciousUserType = "MANUALLY_ADDED"
+	SuspiciousUserTypeDetectedBanEvader     SuspiciousUserType = "DETECTED_BAN_EVADER"
+	SuspiciousUserTypeDetectedSusChatter    SuspiciousUserType = "DETECTED_SUS_CHATTER"
+	SuspiciousUserTypeBannedInSharedChannel SuspiciousUserType = "BANNED_IN_SHARED_CHANNEL"
+)
+
+// SuspiciousUserAction describes a user's suspicious status after it is applied
+// or removed.
+type SuspiciousUserAction struct {
+	UserID        string               `json:"user_id"`
+	BroadcasterID string               `json:"broadcaster_id"`
+	ModeratorID   string               `json:"moderator_id"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+	Status        SuspiciousUserStatus `json:"status"`
+	Types         []SuspiciousUserType `json:"types"`
+}
 
 // AddSuspiciousStatusToChatUserParams contains parameters for AddSuspiciousStatusToChatUser.
 type AddSuspiciousStatusToChatUserParams struct {
 	BroadcasterID string               `json:"-"`
 	ModeratorID   string               `json:"-"`
 	UserID        string               `json:"user_id"`
-	Status        SuspiciousUserStatus `json:"status"`
+	Status        SuspiciousUserStatus `json:"status"` // ACTIVE_MONITORING or RESTRICTED
 }
 
-// AddSuspiciousStatusToChatUser adds a suspicious status to a chat user.
-// The status can be "restricted" or "monitored".
+// AddSuspiciousStatusToChatUser adds a suspicious status to a chat user. The
+// status must be SuspiciousUserStatusActiveMonitoring or
+// SuspiciousUserStatusRestricted, and the applied status is returned.
 // Requires: moderator:manage:suspicious_users scope.
-func (c *Client) AddSuspiciousStatusToChatUser(ctx context.Context, params *AddSuspiciousStatusToChatUserParams) error {
+func (c *Client) AddSuspiciousStatusToChatUser(ctx context.Context, params *AddSuspiciousStatusToChatUserParams) (*SuspiciousUserAction, error) {
 	q := url.Values{}
 	q.Set("broadcaster_id", params.BroadcasterID)
 	q.Set("moderator_id", params.ModeratorID)
 
-	return c.post(ctx, "/moderation/suspicious_users", q, params, nil)
+	var resp Response[SuspiciousUserAction]
+	if err := c.post(ctx, "/moderation/suspicious_users", q, params, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Data) == 0 {
+		return nil, nil
+	}
+	return &resp.Data[0], nil
 }
 
 // RemoveSuspiciousStatusFromChatUserParams contains parameters for RemoveSuspiciousStatusFromChatUser.
@@ -557,13 +588,21 @@ type RemoveSuspiciousStatusFromChatUserParams struct {
 	UserID        string `json:"-"`
 }
 
-// RemoveSuspiciousStatusFromChatUser removes a suspicious status from a chat user.
+// RemoveSuspiciousStatusFromChatUser removes a suspicious status from a chat
+// user. The resulting status (NO_TREATMENT) is returned.
 // Requires: moderator:manage:suspicious_users scope.
-func (c *Client) RemoveSuspiciousStatusFromChatUser(ctx context.Context, params *RemoveSuspiciousStatusFromChatUserParams) error {
+func (c *Client) RemoveSuspiciousStatusFromChatUser(ctx context.Context, params *RemoveSuspiciousStatusFromChatUserParams) (*SuspiciousUserAction, error) {
 	q := url.Values{}
 	q.Set("broadcaster_id", params.BroadcasterID)
 	q.Set("moderator_id", params.ModeratorID)
 	q.Set("user_id", params.UserID)
 
-	return c.delete(ctx, "/moderation/suspicious_users", q, nil)
+	var resp Response[SuspiciousUserAction]
+	if err := c.delete(ctx, "/moderation/suspicious_users", q, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Data) == 0 {
+		return nil, nil
+	}
+	return &resp.Data[0], nil
 }

--- a/helix/moderation_test.go
+++ b/helix/moderation_test.go
@@ -1311,14 +1311,22 @@ func TestClient_AddSuspiciousStatusToChatUser(t *testing.T) {
 			t.Errorf("expected user_id=%s, got %s", twitchBanUserID, body.UserID)
 		}
 		if body.Status != SuspiciousUserStatusRestricted {
-			t.Errorf("expected status=restricted, got %s", body.Status)
+			t.Errorf("expected status=RESTRICTED, got %s", body.Status)
 		}
 
-		w.WriteHeader(http.StatusNoContent)
+		// Official Twitch example response.
+		_, _ = w.Write([]byte(`{"data":[{
+			"user_id": "9876",
+			"broadcaster_id": "141981764",
+			"moderator_id": "12826",
+			"updated_at": "2025-12-01T23:08:18+00:00",
+			"status": "RESTRICTED",
+			"types": ["MANUALLY_ADDED"]
+		}]}`))
 	})
 	defer server.Close()
 
-	err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
+	action, err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
 		BroadcasterID: twitchBanBroadcasterID,
 		ModeratorID:   twitchBanModeratorID,
 		UserID:        twitchBanUserID,
@@ -1328,30 +1336,45 @@ func TestClient_AddSuspiciousStatusToChatUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if action == nil {
+		t.Fatal("expected action, got nil")
+	}
+	if action.Status != SuspiciousUserStatusRestricted {
+		t.Errorf("expected status RESTRICTED, got %s", action.Status)
+	}
+	if len(action.Types) != 1 || action.Types[0] != SuspiciousUserTypeManuallyAdded {
+		t.Errorf("expected types [MANUALLY_ADDED], got %v", action.Types)
+	}
+	if action.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be parsed")
+	}
 }
 
-func TestClient_AddSuspiciousStatusToChatUser_Monitored(t *testing.T) {
+func TestClient_AddSuspiciousStatusToChatUser_ActiveMonitoring(t *testing.T) {
 	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
 		var body AddSuspiciousStatusToChatUserParams
 		_ = json.NewDecoder(r.Body).Decode(&body)
 
-		if body.Status != SuspiciousUserStatusMonitored {
-			t.Errorf("expected status=monitored, got %s", body.Status)
+		if body.Status != SuspiciousUserStatusActiveMonitoring {
+			t.Errorf("expected status=ACTIVE_MONITORING, got %s", body.Status)
 		}
 
-		w.WriteHeader(http.StatusNoContent)
+		_, _ = w.Write([]byte(`{"data":[{"user_id":"9876","status":"ACTIVE_MONITORING","types":["MANUALLY_ADDED"]}]}`))
 	})
 	defer server.Close()
 
-	err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
+	action, err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
 		BroadcasterID: twitchBanBroadcasterID,
 		ModeratorID:   twitchBanModeratorID,
 		UserID:        twitchBanUserID,
-		Status:        SuspiciousUserStatusMonitored,
+		Status:        SuspiciousUserStatusActiveMonitoring,
 	})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if action == nil || action.Status != SuspiciousUserStatusActiveMonitoring {
+		t.Errorf("expected status ACTIVE_MONITORING, got %+v", action)
 	}
 }
 
@@ -1362,7 +1385,7 @@ func TestClient_AddSuspiciousStatusToChatUser_Error(t *testing.T) {
 	})
 	defer server.Close()
 
-	err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
+	_, err := client.AddSuspiciousStatusToChatUser(context.Background(), &AddSuspiciousStatusToChatUserParams{
 		BroadcasterID: twitchBanBroadcasterID,
 		ModeratorID:   twitchBanModeratorID,
 		UserID:        twitchBanUserID,
@@ -1397,11 +1420,19 @@ func TestClient_RemoveSuspiciousStatusFromChatUser(t *testing.T) {
 			t.Errorf("expected user_id=%s, got %s", twitchBanUserID, userID)
 		}
 
-		w.WriteHeader(http.StatusNoContent)
+		// Official Twitch example response (status NO_TREATMENT after removal).
+		_, _ = w.Write([]byte(`{"data":[{
+			"user_id": "9876",
+			"broadcaster_id": "141981764",
+			"moderator_id": "12826",
+			"updated_at": "2025-12-01T23:08:18+00:00",
+			"status": "NO_TREATMENT",
+			"types": ["MANUALLY_ADDED"]
+		}]}`))
 	})
 	defer server.Close()
 
-	err := client.RemoveSuspiciousStatusFromChatUser(context.Background(), &RemoveSuspiciousStatusFromChatUserParams{
+	action, err := client.RemoveSuspiciousStatusFromChatUser(context.Background(), &RemoveSuspiciousStatusFromChatUserParams{
 		BroadcasterID: twitchBanBroadcasterID,
 		ModeratorID:   twitchBanModeratorID,
 		UserID:        twitchBanUserID,
@@ -1409,6 +1440,9 @@ func TestClient_RemoveSuspiciousStatusFromChatUser(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if action == nil || action.Status != SuspiciousUserStatusNoTreatment {
+		t.Errorf("expected status NO_TREATMENT, got %+v", action)
 	}
 }
 
@@ -1419,7 +1453,7 @@ func TestClient_RemoveSuspiciousStatusFromChatUser_Error(t *testing.T) {
 	})
 	defer server.Close()
 
-	err := client.RemoveSuspiciousStatusFromChatUser(context.Background(), &RemoveSuspiciousStatusFromChatUserParams{
+	_, err := client.RemoveSuspiciousStatusFromChatUser(context.Background(), &RemoveSuspiciousStatusFromChatUserParams{
 		BroadcasterID: twitchBanBroadcasterID,
 		ModeratorID:   twitchBanModeratorID,
 		UserID:        twitchBanUserID,


### PR DESCRIPTION
## Description

Corrects the **Add/Remove Suspicious Status to Chat User** endpoints against the official Twitch API reference. The path, query params, and body field name (`status`) were already correct; the enum values and response handling were not:

- **Enum values:** `SuspiciousUserStatus` is now `ACTIVE_MONITORING` / `RESTRICTED` (was `monitored` / `restricted` — the API rejects the lowercase values). Renamed `SuspiciousUserStatusMonitored` → `SuspiciousUserStatusActiveMonitoring`, added `SuspiciousUserStatusNoTreatment` (the remove-response value).
- **Response body:** both endpoints now return `(*SuspiciousUserAction, error)` with the documented response (`updated_at`, `status`, `types`) instead of discarding it.
- Added the `SuspiciousUserAction` and `SuspiciousUserType` types.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] Tests updated to use the official example payloads (`RESTRICTED` + `MANUALLY_ADDED`; remove → `NO_TREATMENT`)
- [x] `go build`, `go vet`, and the full suite pass

## Documentation
- [x] Updated `docs/moderation.md`