### PR TITLE
Add GetCustomPowerUp endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `GetCustomPowerUp` (`GET /bits/custom_power_ups`) and the `CustomPowerUp` type, returning a broadcaster's configured custom Bits Power-ups
 
 ### Changed
 

--- a/docs/bits.md
+++ b/docs/bits.md
@@ -297,3 +297,61 @@ for _, cheermote := range resp.Data {
 }
 ```
 
+## GetCustomPowerUp
+
+Get a broadcaster's configured custom Bits Power-ups.
+
+**Requires:** user access token with the `bits:read` scope
+
+```go
+resp, err := client.GetCustomPowerUp(ctx, &helix.GetCustomPowerUpParams{
+    BroadcasterID: "274637212",
+    // Optional: filter to specific Power-up IDs (max 50)
+    IDs: []string{"92af127c-7326-4483-a52b-b0da0be61c02"},
+})
+if err != nil {
+    // handle error
+}
+
+for _, pu := range resp.Data {
+    fmt.Printf("%s — %d bits (enabled: %t)\n", pu.Title, pu.Bits, pu.IsEnabled)
+}
+```
+
+**Parameters:**
+- `BroadcasterID` (string, required): The broadcaster whose custom Power-ups to get. Must match the user ID in the OAuth token.
+- `IDs` ([]string, optional): Filter by Power-up IDs (max 50).
+
+**Sample Response:**
+```json
+{
+  "data": [
+    {
+      "broadcaster_name": "torpedo09",
+      "broadcaster_login": "torpedo09",
+      "broadcaster_id": "274637212",
+      "id": "92af127c-7326-4483-a52b-b0da0be61c02",
+      "image": null,
+      "background_color": "#00FF00",
+      "is_enabled": true,
+      "bits": 100,
+      "title": "game analysis",
+      "prompt": "",
+      "is_user_input_required": false,
+      "max_per_stream_setting": { "is_enabled": false, "max_per_stream": 0 },
+      "max_per_user_per_stream_setting": { "is_enabled": false, "max_per_user_per_stream": 0 },
+      "global_cooldown_setting": { "is_enabled": false, "global_cooldown_seconds": 0 },
+      "is_paused": false,
+      "is_in_stock": true,
+      "default_image": {
+        "url_1x": "https://static-cdn.jtvnw.net/.../28x28.png",
+        "url_2x": "https://static-cdn.jtvnw.net/.../56x56.png",
+        "url_4x": "https://static-cdn.jtvnw.net/.../112x112.png"
+      },
+      "redemptions_redeemed_current_stream": null,
+      "cooldown_expires_at": null
+    }
+  ]
+}
+```
+

--- a/helix/bits.go
+++ b/helix/bits.go
@@ -107,3 +107,50 @@ func (c *Client) GetCheermotes(ctx context.Context, broadcasterID string) (*Resp
 	}
 	return &resp, nil
 }
+
+// CustomPowerUp represents a broadcaster's custom Bits Power-up.
+// The nested settings reuse the channel points reward types, which share the
+// same JSON shape.
+type CustomPowerUp struct {
+	BroadcasterID                    string              `json:"broadcaster_id"`
+	BroadcasterLogin                 string              `json:"broadcaster_login"`
+	BroadcasterName                  string              `json:"broadcaster_name"`
+	ID                               string              `json:"id"`
+	Title                            string              `json:"title"`
+	Prompt                           string              `json:"prompt"`
+	Bits                             int                 `json:"bits"`
+	Image                            *RewardImage        `json:"image,omitempty"` // null if the broadcaster didn't upload images
+	DefaultImage                     RewardImage         `json:"default_image"`
+	BackgroundColor                  string              `json:"background_color"`
+	IsEnabled                        bool                `json:"is_enabled"`
+	IsUserInputRequired              bool                `json:"is_user_input_required"`
+	MaxPerStreamSetting              MaxPerStream        `json:"max_per_stream_setting"`
+	MaxPerUserPerStreamSetting       MaxPerUserPerStream `json:"max_per_user_per_stream_setting"`
+	GlobalCooldownSetting            GlobalCooldown      `json:"global_cooldown_setting"`
+	IsPaused                         bool                `json:"is_paused"`
+	IsInStock                        bool                `json:"is_in_stock"`
+	RedemptionsRedeemedCurrentStream int                 `json:"redemptions_redeemed_current_stream,omitempty"` // null if not live or no per-stream limit
+	CooldownExpiresAt                *time.Time          `json:"cooldown_expires_at,omitempty"`                 // null when not in cooldown
+}
+
+// GetCustomPowerUpParams contains parameters for GetCustomPowerUp.
+type GetCustomPowerUpParams struct {
+	BroadcasterID string   // Must match the user ID in the OAuth token
+	IDs           []string // Filter by Power-up IDs (max 50)
+}
+
+// GetCustomPowerUp gets the broadcaster's custom Bits Power-ups.
+// Requires: user access token with the bits:read scope.
+func (c *Client) GetCustomPowerUp(ctx context.Context, params *GetCustomPowerUpParams) (*Response[CustomPowerUp], error) {
+	q := url.Values{}
+	q.Set("broadcaster_id", params.BroadcasterID)
+	for _, id := range params.IDs {
+		q.Add("id", id)
+	}
+
+	var resp Response[CustomPowerUp]
+	if err := c.get(ctx, "/bits/custom_power_ups", q, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/helix/bits_test.go
+++ b/helix/bits_test.go
@@ -178,6 +178,79 @@ func TestClient_GetCheermotes(t *testing.T) {
 	}
 }
 
+func TestClient_GetCustomPowerUp(t *testing.T) {
+	// Official Twitch example response from
+	// https://dev.twitch.tv/docs/api/reference#get-custom-power-up
+	const body = `{
+		"data": [{
+			"broadcaster_name": "torpedo09",
+			"broadcaster_login": "torpedo09",
+			"broadcaster_id": "274637212",
+			"id": "92af127c-7326-4483-a52b-b0da0be61c02",
+			"image": null,
+			"background_color": "#00FF00",
+			"is_enabled": true,
+			"bits": 100,
+			"title": "game analysis",
+			"prompt": "",
+			"is_user_input_required": false,
+			"max_per_stream_setting": {"is_enabled": false, "max_per_stream": 0},
+			"max_per_user_per_stream_setting": {"is_enabled": false, "max_per_user_per_stream": 0},
+			"global_cooldown_setting": {"is_enabled": false, "global_cooldown_seconds": 0},
+			"is_paused": false,
+			"is_in_stock": true,
+			"default_image": {
+				"url_1x": "https://static-cdn.jtvnw.net/x-28x28.png",
+				"url_2x": "https://static-cdn.jtvnw.net/x-56x56.png",
+				"url_4x": "https://static-cdn.jtvnw.net/x-112x112.png"
+			},
+			"redemptions_redeemed_current_stream": null,
+			"cooldown_expires_at": null
+		}]
+	}`
+
+	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/bits/custom_power_ups" {
+			t.Errorf("expected /bits/custom_power_ups, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("broadcaster_id"); got != "274637212" {
+			t.Errorf("expected broadcaster_id=274637212, got %s", got)
+		}
+		if ids := r.URL.Query()["id"]; len(ids) != 1 || ids[0] != "92af127c-7326-4483-a52b-b0da0be61c02" {
+			t.Errorf("expected single id query param, got %v", ids)
+		}
+		_, _ = w.Write([]byte(body))
+	})
+	defer server.Close()
+
+	resp, err := client.GetCustomPowerUp(context.Background(), &GetCustomPowerUpParams{
+		BroadcasterID: "274637212",
+		IDs:           []string{"92af127c-7326-4483-a52b-b0da0be61c02"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 power-up, got %d", len(resp.Data))
+	}
+	pu := resp.Data[0]
+	if pu.ID != "92af127c-7326-4483-a52b-b0da0be61c02" || pu.Bits != 100 || pu.Title != "game analysis" {
+		t.Errorf("core fields not decoded: %+v", pu)
+	}
+	if pu.Image != nil {
+		t.Errorf("Image = %+v, want nil for null image", pu.Image)
+	}
+	if pu.DefaultImage.URL1x != "https://static-cdn.jtvnw.net/x-28x28.png" {
+		t.Errorf("DefaultImage.URL1x = %q", pu.DefaultImage.URL1x)
+	}
+	if pu.GlobalCooldownSetting.IsEnabled || pu.MaxPerStreamSetting.MaxPerStream != 0 {
+		t.Errorf("settings not decoded: %+v", pu)
+	}
+	if pu.CooldownExpiresAt != nil {
+		t.Errorf("CooldownExpiresAt = %v, want nil", pu.CooldownExpiresAt)
+	}
+}
+
 func TestClient_GetCheermotes_Global(t *testing.T) {
 	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
 		broadcasterID := r.URL.Query().Get("broadcaster_id")


### PR DESCRIPTION
## Description

Implements the **Get Custom Power-up** Helix endpoint, which was missing from the library.

- `GetCustomPowerUp(ctx, *GetCustomPowerUpParams) (*Response[CustomPowerUp], error)` → `GET /bits/custom_power_ups`
- Auth: user access token with the `bits:read` scope
- Params: `broadcaster_id` (required), `id` (optional, repeatable, max 50)
- The `CustomPowerUp` type matches the documented response and **reuses** the existing channel-points reward types (`RewardImage`, `MaxPerStream`, `MaxPerUserPerStream`, `GlobalCooldown`), which share the same JSON shape.

Note: this is the *custom Power-up resource* (a broadcaster's configured Power-up), distinct from the `custom_power_up` usage object in the `channel.bits.use` EventSub event.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] `TestClient_GetCustomPowerUp` driven by Twitch's official example response
- [x] `go build`, `go vet`, and the full suite pass

## Documentation
- [x] Added a `GetCustomPowerUp` section to `docs/bits.md`