### PR TITLE
Add WithEventSubWSURL and expand test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `WithEventSubWSURL` option to point the high-level `EventSubWebSocket` at a custom WebSocket URL (useful for testing)
 
 ### Changed
+- Expanded test coverage (cache context invalidation, IRC timestamp fallback, WebSocket close-error classification, and the high-level `EventSubWebSocket.Connect` success/reconnect/error paths)
 
 ### Fixed
 

--- a/helix/cache_test.go
+++ b/helix/cache_test.go
@@ -309,6 +309,36 @@ func TestClient_InvalidateCache_NoCache(t *testing.T) {
 	client.InvalidateCache(context.Background(), "/users", "id=123")
 }
 
+func TestClient_InvalidateCacheWithContext(t *testing.T) {
+	cache := NewMemoryCache(100)
+	ctx := context.Background()
+
+	authClient := NewAuthClient(AuthConfig{
+		ClientID: "test-client-id",
+	})
+	client := NewClient("test-client-id", authClient, WithCache(cache, time.Minute))
+
+	tokenHash := TokenHash("user-token")
+	key := CacheKeyWithContext(client.baseURL, "/users", "id=123", tokenHash)
+	cache.Set(ctx, key, []byte("cached"), time.Minute)
+
+	client.InvalidateCacheWithContext(ctx, "/users", "id=123", tokenHash)
+
+	if cache.Get(ctx, key) != nil {
+		t.Error("expected context-aware cache entry to be invalidated")
+	}
+}
+
+func TestClient_InvalidateCacheWithContext_NoCache(t *testing.T) {
+	authClient := NewAuthClient(AuthConfig{
+		ClientID: "test-client-id",
+	})
+	client := NewClient("test-client-id", authClient)
+
+	// Should not panic when no cache is set
+	client.InvalidateCacheWithContext(context.Background(), "/users", "id=123", TokenHash("user-token"))
+}
+
 func TestNoCacheContext(t *testing.T) {
 	ctx := context.Background()
 	noCacheCtx := NoCacheContext(ctx)

--- a/helix/eventsub_websocket.go
+++ b/helix/eventsub_websocket.go
@@ -549,6 +549,7 @@ type EventSubWebSocket struct {
 	client    *Client
 	ws        *EventSubWebSocketClient
 	sessionID string
+	wsURL     string // overrides the default Twitch URL (useful for testing)
 
 	mu       sync.RWMutex
 	handlers map[string]func(json.RawMessage)
@@ -584,6 +585,13 @@ func WithEventSubErrorHandler(fn func(error)) EventSubWebSocketOption {
 	}
 }
 
+// WithEventSubWSURL sets a custom WebSocket URL (useful for testing).
+func WithEventSubWSURL(url string) EventSubWebSocketOption {
+	return func(e *EventSubWebSocket) {
+		e.wsURL = url
+	}
+}
+
 // NewEventSubWebSocket creates a new high-level EventSub WebSocket manager.
 // Returns nil if helixClient is nil.
 func NewEventSubWebSocket(helixClient *Client, opts ...EventSubWebSocketOption) *EventSubWebSocket {
@@ -611,7 +619,7 @@ func (e *EventSubWebSocket) Connect(ctx context.Context) error {
 		e.sessionID = ""
 	}
 
-	e.ws = NewEventSubWebSocketClient(
+	wsOpts := []EventSubWSOption{
 		WithWSNotificationHandler(func(sub *EventSubSubscription, event json.RawMessage) {
 			e.mu.RLock()
 			handler, ok := e.handlers[sub.Type]
@@ -640,7 +648,11 @@ func (e *EventSubWebSocket) Connect(ctx context.Context) error {
 				e.onError(err)
 			}
 		}),
-	)
+	}
+	if e.wsURL != "" {
+		wsOpts = append(wsOpts, WithWSURL(e.wsURL))
+	}
+	e.ws = NewEventSubWebSocketClient(wsOpts...)
 
 	sessionID, err := e.ws.Connect(ctx)
 	if err != nil {

--- a/helix/eventsub_websocket_test.go
+++ b/helix/eventsub_websocket_test.go
@@ -87,6 +87,27 @@ func TestNewEventSubWebSocketClient(t *testing.T) {
 	}
 }
 
+func TestIsExpectedCloseError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"close sent", websocket.ErrCloseSent, true},
+		{"closed network connection", errors.New("write tcp: use of closed network connection"), true},
+		{"i/o timeout", errors.New("read tcp: i/o timeout"), true},
+		{"unrelated", errors.New("some other error"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isExpectedCloseError(tt.err); got != tt.want {
+				t.Errorf("isExpectedCloseError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEventSubWebSocketClient_WithOptions(t *testing.T) {
 	customURL := "wss://custom.example.com/ws"
 	welcomeCalled := false
@@ -1401,37 +1422,27 @@ func TestEventSubWebSocket_Connect(t *testing.T) {
 	})
 	helixClient := NewClient("test-client-id", authClient)
 
-	ws := NewEventSubWebSocket(helixClient)
-	// Inject the mock URL by accessing the internal ws after Connect creates it
-	// We need to set the URL before Connect, so we'll use a workaround
-
-	// Create the internal client manually to set the URL
-	ws.ws = NewEventSubWebSocketClient(
-		WithWSURL(mock.URL()),
-		WithWSNotificationHandler(func(sub *EventSubSubscription, event json.RawMessage) {
-			ws.mu.RLock()
-			handler, ok := ws.handlers[sub.Type]
-			ws.mu.RUnlock()
-			if ok {
-				handler(event)
-			}
-		}),
-	)
+	ws := NewEventSubWebSocket(helixClient, WithEventSubWSURL(mock.URL()))
 
 	ctx := context.Background()
-	sid, err := ws.ws.Connect(ctx)
-	if err != nil {
+	if err := ws.Connect(ctx); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
-	ws.sessionID = sid
 
 	if ws.sessionID != sessionID {
 		t.Errorf("expected session ID %s, got %s", sessionID, ws.sessionID)
 	}
 
+	// Connecting again closes the existing connection first and reconnects.
+	if err := ws.Connect(ctx); err != nil {
+		t.Fatalf("reconnect failed: %v", err)
+	}
+	if ws.sessionID != sessionID {
+		t.Errorf("expected session ID %s after reconnect, got %s", sessionID, ws.sessionID)
+	}
+
 	// Close
-	err = ws.Close()
-	if err != nil {
+	if err := ws.Close(); err != nil {
 		t.Errorf("Close failed: %v", err)
 	}
 }
@@ -1442,16 +1453,17 @@ func TestEventSubWebSocket_ConnectError(t *testing.T) {
 	})
 	helixClient := NewClient("test-client-id", authClient)
 
-	ws := NewEventSubWebSocket(helixClient)
-	// Set invalid URL to force connection error
-	ws.ws = NewEventSubWebSocketClient(WithWSURL("ws://invalid.invalid:9999"))
+	// Set invalid URL to force connection error via the high-level Connect.
+	ws := NewEventSubWebSocket(helixClient, WithEventSubWSURL("ws://invalid.invalid:9999"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	_, err := ws.ws.Connect(ctx)
-	if err == nil {
+	if err := ws.Connect(ctx); err == nil {
 		t.Error("expected connect error")
+	}
+	if ws.ws != nil {
+		t.Error("expected ws to be nil after a failed Connect")
 	}
 }
 
@@ -1504,29 +1516,16 @@ func TestEventSubWebSocket_Subscribe(t *testing.T) {
 	})
 	helixClient := NewClient("test-client-id", authClient, WithBaseURL(apiServer.URL))
 
-	ws := NewEventSubWebSocket(helixClient)
-	ws.ws = NewEventSubWebSocketClient(
-		WithWSURL(wsMock.URL()),
-		WithWSNotificationHandler(func(sub *EventSubSubscription, event json.RawMessage) {
-			ws.mu.RLock()
-			handler, ok := ws.handlers[sub.Type]
-			ws.mu.RUnlock()
-			if ok {
-				handler(event)
-			}
-		}),
-	)
+	ws := NewEventSubWebSocket(helixClient, WithEventSubWSURL(wsMock.URL()))
 
 	ctx := context.Background()
-	sid, err := ws.ws.Connect(ctx)
-	if err != nil {
+	if err := ws.Connect(ctx); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
-	ws.sessionID = sid
 
 	// Subscribe
 	handlerCalled := false
-	err = ws.Subscribe(ctx, EventSubTypeChannelFollow, "2", map[string]string{
+	err := ws.Subscribe(ctx, EventSubTypeChannelFollow, "2", map[string]string{
 		"broadcaster_user_id": twitchWSExampleBroadcasterUserID,
 		"moderator_user_id":   twitchWSExampleUserID,
 	}, func(event json.RawMessage) {

--- a/helix/irc_test.go
+++ b/helix/irc_test.go
@@ -467,6 +467,18 @@ func TestParseTimestamp(t *testing.T) {
 	}
 }
 
+func TestParseTimestamp_FallsBackToNow(t *testing.T) {
+	// An empty or unparseable timestamp falls back to the current time.
+	for _, in := range []string{"", "not-a-number"} {
+		before := time.Now()
+		ts := parseTimestamp(in)
+		after := time.Now()
+		if ts.Before(before) || ts.After(after) {
+			t.Errorf("parseTimestamp(%q) = %v, expected a time within [%v, %v]", in, ts, before, after)
+		}
+	}
+}
+
 func TestParseUserFromPrefix(t *testing.T) {
 	tests := []struct {
 		prefix   string


### PR DESCRIPTION
## Description

- Adds `WithEventSubWSURL`, a testing hook on the high-level `EventSubWebSocket` (mirrors the low-level `WithWSURL`), so its `Connect` success path can be exercised against a mock server.
- Converts the `EventSubWebSocket` `Connect` / `ConnectError` / `Subscribe` tests to drive the **real** high-level `Connect` instead of a `ws.ws = …` workaround.
- Adds tests for previously-uncovered code: `InvalidateCacheWithContext`, `isExpectedCloseError` (all branches), and the `parseTimestamp` empty/unparseable fallback.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] `go build`, `go vet`, and the full suite pass