### PR TITLE
Add missing documented fields (url_template_secure, aggression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `IngestServer.URLTemplateSecure` (`url_template_secure`) — the RTMPS ingest URL template returned by the ingest endpoint
+- `AutomodSettingsUpdateEvent.Aggression` (`aggression`) — the documented AutoMod category level was missing from the `automod.settings.update` event
 
 ### Changed
 

--- a/helix/eventsub_events.go
+++ b/helix/eventsub_events.go
@@ -680,6 +680,7 @@ type AutomodMessageUpdateEvent struct {
 type AutomodSettingsUpdateEvent struct {
 	EventSubBroadcaster
 	EventSubModerator
+	Aggression            int  `json:"aggression"`
 	BulliedUsers          int  `json:"bullying"`
 	Disability            int  `json:"disability"`
 	Misogyny              int  `json:"misogyny"`

--- a/helix/eventsub_events_test.go
+++ b/helix/eventsub_events_test.go
@@ -8,6 +8,45 @@ import (
 // Tests for eventsub_events.go event types using official Twitch API documentation payloads.
 // Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/
 
+// TestAutomodSettingsUpdateEvent_Aggression verifies the automod.settings.update
+// payload decodes all category levels, including the "aggression" field.
+func TestAutomodSettingsUpdateEvent_Aggression(t *testing.T) {
+	payload := []byte(`{
+		"broadcaster_user_id": "1337",
+		"broadcaster_user_login": "cool_user",
+		"broadcaster_user_name": "Cool_User",
+		"moderator_user_id": "9001",
+		"moderator_user_login": "the_mod",
+		"moderator_user_name": "The_Mod",
+		"overall_level": null,
+		"disability": 1,
+		"aggression": 2,
+		"sexuality_sex_or_gender": 3,
+		"misogyny": 0,
+		"bullying": 1,
+		"swearing": 0,
+		"race_ethnicity_or_religion": 4,
+		"sex_based_terms": 2
+	}`)
+
+	var event AutomodSettingsUpdateEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if event.BroadcasterUserID != "1337" || event.ModeratorUserID != "9001" {
+		t.Errorf("embedded broadcaster/moderator not decoded: %+v", event)
+	}
+	if event.Aggression != 2 {
+		t.Errorf("Aggression = %d, want 2", event.Aggression)
+	}
+	if event.OverallLevel != nil {
+		t.Errorf("OverallLevel = %v, want nil", event.OverallLevel)
+	}
+	if event.RaceEthnicityReligion != 4 || event.SexBasedTerms != 2 {
+		t.Errorf("category levels not decoded: %+v", event)
+	}
+}
+
 func TestHypeTrainBeginEvent_V1ToV2Conversion(t *testing.T) {
 	// Official Twitch v1 example from https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainbegin
 	// Modified is_golden_kappa_train to true for golden kappa test

--- a/helix/ingest.go
+++ b/helix/ingest.go
@@ -15,12 +15,13 @@ const (
 
 // IngestServer represents a Twitch ingest server for live video streaming.
 type IngestServer struct {
-	ID           int     `json:"_id"`
-	Availability float64 `json:"availability"`
-	Default      bool    `json:"default"`
-	Name         string  `json:"name"`
-	URLTemplate  string  `json:"url_template"`
-	Priority     int     `json:"priority"`
+	ID                int     `json:"_id"`
+	Availability      float64 `json:"availability"`
+	Default           bool    `json:"default"`
+	Name              string  `json:"name"`
+	URLTemplate       string  `json:"url_template"`        // RTMP ingest URL template
+	URLTemplateSecure string  `json:"url_template_secure"` // RTMPS (TLS) ingest URL template
+	Priority          int     `json:"priority"`
 }
 
 // IngestServersResponse represents the response from the ingest servers endpoint.

--- a/helix/ingest_test.go
+++ b/helix/ingest_test.go
@@ -31,12 +31,13 @@ func TestClient_GetIngestServers(t *testing.T) {
 		resp := IngestServersResponse{
 			Ingests: []IngestServer{
 				{
-					ID:           1,
-					Availability: 1.0,
-					Default:      false,
-					Name:         "US East: Atlanta, GA",
-					URLTemplate:  "rtmp://atl.contribute.live-video.net/app/{stream_key}",
-					Priority:     13,
+					ID:                1,
+					Availability:      1.0,
+					Default:           false,
+					Name:              "US East: Atlanta, GA",
+					URLTemplate:       "rtmp://atl.contribute.live-video.net/app/{stream_key}",
+					URLTemplateSecure: "rtmps://atl.contribute.live-video.net/app/{stream_key}",
+					Priority:          13,
 				},
 				{
 					ID:           2,
@@ -72,6 +73,9 @@ func TestClient_GetIngestServers(t *testing.T) {
 	}
 	if resp.Ingests[0].Name != "US East: Atlanta, GA" {
 		t.Errorf("expected first server name 'US East: Atlanta, GA', got %s", resp.Ingests[0].Name)
+	}
+	if resp.Ingests[0].URLTemplateSecure != "rtmps://atl.contribute.live-video.net/app/{stream_key}" {
+		t.Errorf("expected secure URL template to decode, got %q", resp.Ingests[0].URLTemplateSecure)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds two documented response fields that were missing from their structs:

- **`IngestServer.URLTemplateSecure`** (`url_template_secure`) — the RTMPS (TLS) ingest URL template. Verified present in the live `https://ingest.twitch.tv/ingests` response.
- **`AutomodSettingsUpdateEvent.Aggression`** (`aggression`) — a documented AutoMod category level that was missing from the `automod.settings.update` event payload (the sibling REST `AutoModSettings` already had it).

Note: a third candidate from the original audit — `CharityCampaign.started_at` — was a **false positive**; the Get Charity Campaign response has no `started_at` (that field belongs to the charity *start event*), confirmed against the reference and nicklaw5/helix. No change made there.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] `IngestServer` test asserts `url_template_secure` decodes; new `TestAutomodSettingsUpdateEvent_Aggression` covers the event payload
- [x] `go build`, `go vet`, and the full suite pass