### PR TITLE
Fix clip-download and user-authorization endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
 ### Fixed
+- **BREAKING:** Corrected `GetClipsDownload` to match the Twitch reference: endpoint path `/clips/download` → `/clips/downloads`; it now takes `*GetClipsDownloadParams` (`BroadcasterID`, `EditorID`, `ClipIDs`) and `ClipDownload` exposes `ClipID`/`LandscapeDownloadURL`/`PortraitDownloadURL` (was `ID`/`URL`/`ExpiresAt`)
+- **BREAKING:** `CreateClipFromVOD` now sends its parameters as query parameters (the Twitch endpoint reads them from the query string; they were incorrectly sent as a JSON body)
+- **BREAKING:** Corrected `GetAuthorizationByUser` to match the Twitch reference: endpoint path `/users/authorization` → `/authorization/users`; it now takes `UserIDs []string` (up to 10) and `UserAuthorization` exposes `UserID`/`UserName`/`UserLogin`/`Scopes` (removed the non-existent `ClientID`, renamed `Login` → `UserLogin`)
 
 ## [1.2.2] - 2026-04-23 ([#75](https://github.com/Its-donkey/kappopher/pull/75))
 

--- a/docs/clips.md
+++ b/docs/clips.md
@@ -224,44 +224,47 @@ if resp.Pagination.Cursor != "" {
 
 ## GetClipsDownload
 
-Get download URLs for clips. The URLs are temporary and expire after a short time.
+Provides URLs to download the video file(s) for the specified clips (up to 10).
 
-**Requires:** `clips:edit` scope for clips the user created or for the broadcaster's clips
+**Requires:** `editor:manage:clips` or `channel:manage:clips` scope
 
 ```go
 resp, err := client.GetClipsDownload(ctx, &helix.GetClipsDownloadParams{
-    ClipIDs: []string{"clip1", "clip2", "clip3"},
+    BroadcasterID: "141981764",
+    EditorID:      "141981764", // same as BroadcasterID when using the broadcaster's token
+    ClipIDs:       []string{"InexpensiveDistinctFoxChefFrank", "SpinelessCloudyLeopardMcaT"},
 })
 if err != nil {
     log.Fatal(err)
 }
 for _, clip := range resp.Data {
-    fmt.Printf("Clip ID: %s, Download URL: %s (expires: %s)\n",
-        clip.ID, clip.URL, clip.ExpiresAt)
+    fmt.Printf("Clip %s: %s\n", clip.ClipID, clip.LandscapeDownloadURL)
 }
 ```
 
 **Parameters:**
-- `ClipIDs` ([]string): Array of clip IDs to get download URLs for
+- `BroadcasterID` (string, required): Broadcaster whose clips to download
+- `EditorID` (string, required): Editor user ID; must match the token's user ID (equals `BroadcasterID` when using the broadcaster's token)
+- `ClipIDs` ([]string, required): Clip IDs to download (max 10)
 
 **Returns:**
-- `ID` (string): The clip ID
-- `URL` (string): Temporary download URL for the clip
-- `ExpiresAt` (string): When the download URL expires
+- `ClipID` (string): The clip ID
+- `LandscapeDownloadURL` (string): Landscape download URL (empty if unavailable)
+- `PortraitDownloadURL` (string): Portrait download URL (empty if unavailable)
 
 **Sample Response:**
 ```json
 {
   "data": [
     {
-      "id": "AwkwardHelplessSalamanderSwiftRage",
-      "url": "https://production.assets.clips.twitchcdn.net/vod-123456789-offset-123.mp4",
-      "expires_at": "2023-12-15T10:30:00Z"
+      "clip_id": "InexpensiveDistinctFoxChefFrank",
+      "landscape_download_url": "https://production.assets.clips.twitchcdn.net/yFZG...",
+      "portrait_download_url": null
     },
     {
-      "id": "TameIntelligentCarabeefBudStar",
-      "url": "https://production.assets.clips.twitchcdn.net/vod-987654321-offset-456.mp4",
-      "expires_at": "2023-12-15T10:30:00Z"
+      "clip_id": "SpinelessCloudyLeopardMcaT",
+      "landscape_download_url": "https://production.assets.clips.twitchcdn.net/542j...",
+      "portrait_download_url": null
     }
   ]
 }

--- a/docs/users.md
+++ b/docs/users.md
@@ -433,36 +433,38 @@ if err != nil {
 
 ## GetAuthorizationByUser
 
-Get authorization information for a user who has authorized your app.
+Gets the authorization scopes that the specified users (up to 10) have granted your application.
 
 **Requires:** App access token
 
 ```go
 resp, err := client.GetAuthorizationByUser(ctx, &helix.GetAuthorizationByUserParams{
-    UserID: "12345",
+    UserIDs: []string{"141981764", "197886470"},
 })
 
-auth := resp.Data[0]
-fmt.Printf("Client ID: %s\n", auth.ClientID)
-fmt.Printf("User: %s (%s)\n", auth.Login, auth.UserID)
-fmt.Printf("Scopes: %v\n", auth.Scopes)
+for _, auth := range resp.Data {
+    fmt.Printf("%s (%s): %v\n", auth.UserName, auth.UserLogin, auth.Scopes)
+}
 ```
+
+**Parameters:**
+- `UserIDs` ([]string, required): User IDs to check (max 10)
 
 **Sample Response:**
 ```json
 {
   "data": [
     {
-      "client_id": "hof5gwx0su6owfnys0yan9c87zr6t",
       "user_id": "141981764",
-      "login": "twitchdev",
-      "scopes": [
-        "channel:read:subscriptions",
-        "user:read:email",
-        "user:edit",
-        "chat:read",
-        "chat:edit"
-      ]
+      "user_name": "TwitchDev",
+      "user_login": "twitchdev",
+      "scopes": ["bits:read", "channel:bot", "channel:manage:predictions"]
+    },
+    {
+      "user_id": "197886470",
+      "user_name": "TwitchRivals",
+      "user_login": "twitchrivals",
+      "scopes": ["channel:manage:predictions"]
     }
   ]
 }

--- a/helix/clips.go
+++ b/helix/clips.go
@@ -3,6 +3,7 @@ package helix
 import (
 	"context"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -103,43 +104,63 @@ func (c *Client) GetClips(ctx context.Context, params *GetClipsParams) (*Respons
 	return &resp, nil
 }
 
-// ClipDownload represents a clip download URL.
+// ClipDownload represents a clip's download URLs.
 type ClipDownload struct {
-	ID        string `json:"id"`
-	URL       string `json:"url"`
-	ExpiresAt string `json:"expires_at"`
+	ClipID               string `json:"clip_id"`
+	LandscapeDownloadURL string `json:"landscape_download_url"` // null if unavailable
+	PortraitDownloadURL  string `json:"portrait_download_url"`  // null if unavailable
 }
 
-// GetClipsDownload gets a download URL for clips.
-// Requires: clips:edit scope for clips the user created, or the broadcaster's clips.
-func (c *Client) GetClipsDownload(ctx context.Context, clipIDs []string) (*Response[ClipDownload], error) {
+// GetClipsDownloadParams contains parameters for GetClipsDownload.
+type GetClipsDownloadParams struct {
+	EditorID      string   // Required: editor user ID (same as BroadcasterID when using the broadcaster token); must match the token's user_id
+	BroadcasterID string   // Required: broadcaster whose clips to download
+	ClipIDs       []string // Required: clip IDs to download (max 10)
+}
+
+// GetClipsDownload provides URLs to download the video files for the specified clips.
+// Requires: editor:manage:clips or channel:manage:clips scope.
+func (c *Client) GetClipsDownload(ctx context.Context, params *GetClipsDownloadParams) (*Response[ClipDownload], error) {
 	q := url.Values{}
-	for _, id := range clipIDs {
-		q.Add("id", id)
+	q.Set("editor_id", params.EditorID)
+	q.Set("broadcaster_id", params.BroadcasterID)
+	for _, id := range params.ClipIDs {
+		q.Add("clip_id", id)
 	}
 
 	var resp Response[ClipDownload]
-	if err := c.get(ctx, "/clips/download", q, &resp); err != nil {
+	if err := c.get(ctx, "/clips/downloads", q, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 // CreateClipFromVODParams contains parameters for CreateClipFromVOD.
+// These are sent as query parameters.
 type CreateClipFromVODParams struct {
-	EditorID      string   `json:"editor_id"`      // Required: User ID of the editor
-	BroadcasterID string   `json:"broadcaster_id"` // Required: User ID of the channel
-	VODID         string   `json:"vod_id"`         // Required: ID of the VOD to clip
-	VODOffset     int      `json:"vod_offset"`     // Required: Offset in seconds where clip ends
-	Title         string   `json:"title"`          // Required: Clip title
-	Duration      *float64 `json:"duration,omitempty"` // Optional: Clip length (5-60 seconds, default 30)
+	EditorID      string   // Required: editor user ID (same as BroadcasterID when using the broadcaster token); must match the token's user_id
+	BroadcasterID string   // Required: channel to clip
+	VODID         string   // Required: ID of the VOD to clip
+	VODOffset     int      // Required: offset (seconds) where the clip ends; must be >= Duration
+	Title         string   // Required: clip title
+	Duration      *float64 // Optional: clip length in seconds (5-60, precision 0.1); defaults to 30
 }
 
-// CreateClipFromVOD creates a clip from a VOD.
+// CreateClipFromVOD creates a clip from a broadcaster's VOD.
 // Requires: editor:manage:clips or channel:manage:clips scope.
 func (c *Client) CreateClipFromVOD(ctx context.Context, params *CreateClipFromVODParams) (*CreateClipResponse, error) {
+	q := url.Values{}
+	q.Set("editor_id", params.EditorID)
+	q.Set("broadcaster_id", params.BroadcasterID)
+	q.Set("vod_id", params.VODID)
+	q.Set("vod_offset", strconv.Itoa(params.VODOffset))
+	q.Set("title", params.Title)
+	if params.Duration != nil {
+		q.Set("duration", strconv.FormatFloat(*params.Duration, 'f', -1, 64))
+	}
+
 	var resp Response[CreateClipResponse]
-	if err := c.post(ctx, "/videos/clips", nil, params, &resp); err != nil {
+	if err := c.post(ctx, "/videos/clips", q, nil, &resp); err != nil {
 		return nil, err
 	}
 	if len(resp.Data) == 0 {

--- a/helix/clips_test.go
+++ b/helix/clips_test.go
@@ -247,34 +247,32 @@ func TestClient_GetClips_DateRange(t *testing.T) {
 
 func TestClient_GetClipsDownload(t *testing.T) {
 	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/clips/download" {
-			t.Errorf("expected /clips/download, got %s", r.URL.Path)
+		if r.URL.Path != "/clips/downloads" {
+			t.Errorf("expected /clips/downloads, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("broadcaster_id"); got != "141981764" {
+			t.Errorf("expected broadcaster_id=141981764, got %s", got)
+		}
+		if got := r.URL.Query().Get("editor_id"); got != "141981764" {
+			t.Errorf("expected editor_id=141981764, got %s", got)
+		}
+		if ids := r.URL.Query()["clip_id"]; len(ids) != 2 {
+			t.Errorf("expected 2 clip_id params, got %d", len(ids))
 		}
 
-		ids := r.URL.Query()["id"]
-		if len(ids) != 2 {
-			t.Errorf("expected 2 ids, got %d", len(ids))
-		}
-
-		resp := Response[ClipDownload]{
-			Data: []ClipDownload{
-				{
-					ID:        "clip1",
-					URL:       "https://example.com/download/clip1.mp4",
-					ExpiresAt: "2024-01-15T12:00:00Z",
-				},
-				{
-					ID:        "clip2",
-					URL:       "https://example.com/download/clip2.mp4",
-					ExpiresAt: "2024-01-15T12:00:00Z",
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
+		// Official Twitch example response.
+		_, _ = w.Write([]byte(`{"data":[
+			{"clip_id":"InexpensiveDistinctFoxChefFrank","landscape_download_url":"https://production.assets.clips.twitchcdn.net/yFZG","portrait_download_url":null},
+			{"clip_id":"SpinelessCloudyLeopardMcaT","landscape_download_url":"https://production.assets.clips.twitchcdn.net/542j","portrait_download_url":null}
+		]}`))
 	})
 	defer server.Close()
 
-	resp, err := client.GetClipsDownload(context.Background(), []string{"clip1", "clip2"})
+	resp, err := client.GetClipsDownload(context.Background(), &GetClipsDownloadParams{
+		BroadcasterID: "141981764",
+		EditorID:      "141981764",
+		ClipIDs:       []string{"InexpensiveDistinctFoxChefFrank", "SpinelessCloudyLeopardMcaT"},
+	})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -282,8 +280,14 @@ func TestClient_GetClipsDownload(t *testing.T) {
 	if len(resp.Data) != 2 {
 		t.Fatalf("expected 2 downloads, got %d", len(resp.Data))
 	}
-	if resp.Data[0].URL == "" {
-		t.Error("expected URL to be set")
+	if resp.Data[0].ClipID != "InexpensiveDistinctFoxChefFrank" {
+		t.Errorf("ClipID = %q", resp.Data[0].ClipID)
+	}
+	if resp.Data[0].LandscapeDownloadURL == "" {
+		t.Error("expected landscape download URL to be set")
+	}
+	if resp.Data[0].PortraitDownloadURL != "" {
+		t.Errorf("expected portrait URL empty for null, got %q", resp.Data[0].PortraitDownloadURL)
 	}
 }
 
@@ -344,7 +348,11 @@ func TestClient_GetClipsDownload_Error(t *testing.T) {
 	})
 	defer server.Close()
 
-	_, err := client.GetClipsDownload(context.Background(), []string{"clip1"})
+	_, err := client.GetClipsDownload(context.Background(), &GetClipsDownloadParams{
+		BroadcasterID: "141981764",
+		EditorID:      "141981764",
+		ClipIDs:       []string{"clip1"},
+	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -421,25 +429,22 @@ func TestClient_CreateClipFromVOD(t *testing.T) {
 			t.Errorf("expected /videos/clips, got %s", r.URL.Path)
 		}
 
-		var body CreateClipFromVODParams
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
+		// Parameters are sent as query parameters, not a JSON body.
+		q := r.URL.Query()
+		if q.Get("editor_id") != "11111" {
+			t.Errorf("expected editor_id=11111, got %s", q.Get("editor_id"))
 		}
-
-		if body.EditorID != "11111" {
-			t.Errorf("expected editor_id=11111, got %s", body.EditorID)
+		if q.Get("broadcaster_id") != "22222" {
+			t.Errorf("expected broadcaster_id=22222, got %s", q.Get("broadcaster_id"))
 		}
-		if body.BroadcasterID != "22222" {
-			t.Errorf("expected broadcaster_id=22222, got %s", body.BroadcasterID)
+		if q.Get("vod_id") != "33333" {
+			t.Errorf("expected vod_id=33333, got %s", q.Get("vod_id"))
 		}
-		if body.VODID != "33333" {
-			t.Errorf("expected vod_id=33333, got %s", body.VODID)
+		if q.Get("vod_offset") != "3600" {
+			t.Errorf("expected vod_offset=3600, got %s", q.Get("vod_offset"))
 		}
-		if body.VODOffset != 3600 {
-			t.Errorf("expected vod_offset=3600, got %d", body.VODOffset)
-		}
-		if body.Title != "Epic Moment" {
-			t.Errorf("expected title=Epic Moment, got %s", body.Title)
+		if q.Get("title") != "Epic Moment" {
+			t.Errorf("expected title=Epic Moment, got %s", q.Get("title"))
 		}
 
 		w.WriteHeader(http.StatusAccepted)
@@ -476,15 +481,8 @@ func TestClient_CreateClipFromVOD(t *testing.T) {
 
 func TestClient_CreateClipFromVOD_WithDuration(t *testing.T) {
 	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
-		var body CreateClipFromVODParams
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-
-		if body.Duration == nil {
-			t.Error("expected duration to be set")
-		} else if *body.Duration != 45.5 {
-			t.Errorf("expected duration=45.5, got %f", *body.Duration)
+		if got := r.URL.Query().Get("duration"); got != "45.5" {
+			t.Errorf("expected duration=45.5 query param, got %q", got)
 		}
 
 		w.WriteHeader(http.StatusAccepted)

--- a/helix/users.go
+++ b/helix/users.go
@@ -211,31 +211,33 @@ func (c *Client) UpdateUserExtensions(ctx context.Context, params *UpdateUserExt
 	return &resp.Data, nil
 }
 
-// UserAuthorization represents the authorization scopes granted by a user.
+// UserAuthorization represents the scopes a user has granted the application.
 type UserAuthorization struct {
-	ClientID string   `json:"client_id"`
-	UserID   string   `json:"user_id"`
-	Login    string   `json:"login"`
-	Scopes   []string `json:"scopes"`
+	UserID    string   `json:"user_id"`
+	UserName  string   `json:"user_name"`
+	UserLogin string   `json:"user_login"`
+	Scopes    []string `json:"scopes"`
 }
 
 // GetAuthorizationByUserParams contains parameters for GetAuthorizationByUser.
 type GetAuthorizationByUserParams struct {
-	UserID string // Required: The ID of a user that granted the application OAuth permissions
+	UserIDs []string // Required: user IDs that granted the application OAuth permissions (max 10)
 }
 
-// GetAuthorizationByUser gets the authorization scopes that the specified user has granted the application.
+// GetAuthorizationByUser gets the authorization scopes that the specified users have granted the application.
 // Requires: App access token.
 func (c *Client) GetAuthorizationByUser(ctx context.Context, params *GetAuthorizationByUserParams) (*Response[UserAuthorization], error) {
-	if params == nil || params.UserID == "" {
-		return nil, fmt.Errorf("user_id is required")
+	if params == nil || len(params.UserIDs) == 0 {
+		return nil, fmt.Errorf("at least one user_id is required")
 	}
 
 	q := url.Values{}
-	q.Set("user_id", params.UserID)
+	for _, id := range params.UserIDs {
+		q.Add("user_id", id)
+	}
 
 	var resp Response[UserAuthorization]
-	if err := c.get(ctx, "/users/authorization", q, &resp); err != nil {
+	if err := c.get(ctx, "/authorization/users", q, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/helix/users_test.go
+++ b/helix/users_test.go
@@ -442,44 +442,35 @@ func TestClient_GetAuthorizationByUser(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/users/authorization" {
-			t.Errorf("expected /users/authorization, got %s", r.URL.Path)
+		if r.URL.Path != "/authorization/users" {
+			t.Errorf("expected /authorization/users, got %s", r.URL.Path)
 		}
 
-		userID := r.URL.Query().Get("user_id")
-		if userID != "12345" {
-			t.Errorf("expected user_id=12345, got %s", userID)
+		ids := r.URL.Query()["user_id"]
+		if len(ids) != 2 || ids[0] != "141981764" {
+			t.Errorf("expected two user_id params, got %v", ids)
 		}
 
-		resp := Response[UserAuthorization]{
-			Data: []UserAuthorization{
-				{
-					ClientID: "client123",
-					UserID:   "12345",
-					Login:    "testuser",
-					Scopes:   []string{"user:read:email", "bits:read", "channel:read:subscriptions"},
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
+		// Official Twitch example response.
+		_, _ = w.Write([]byte(`{"data":[
+			{"user_id":"141981764","user_name":"TwitchDev","user_login":"twitchdev","scopes":["bits:read","channel:bot","channel:manage:predictions"]},
+			{"user_id":"197886470","user_name":"TwitchRivals","user_login":"twitchrivals","scopes":["channel:manage:predictions"]}
+		]}`))
 	})
 	defer server.Close()
 
 	resp, err := client.GetAuthorizationByUser(context.Background(), &GetAuthorizationByUserParams{
-		UserID: "12345",
+		UserIDs: []string{"141981764", "197886470"},
 	})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(resp.Data) != 1 {
-		t.Fatalf("expected 1 authorization, got %d", len(resp.Data))
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 authorizations, got %d", len(resp.Data))
 	}
-	if resp.Data[0].ClientID != "client123" {
-		t.Errorf("expected client_id=client123, got %s", resp.Data[0].ClientID)
-	}
-	if resp.Data[0].Login != "testuser" {
-		t.Errorf("expected login=testuser, got %s", resp.Data[0].Login)
+	if resp.Data[0].UserID != "141981764" || resp.Data[0].UserLogin != "twitchdev" || resp.Data[0].UserName != "TwitchDev" {
+		t.Errorf("user fields not decoded: %+v", resp.Data[0])
 	}
 	if len(resp.Data[0].Scopes) != 3 {
 		t.Errorf("expected 3 scopes, got %d", len(resp.Data[0].Scopes))
@@ -604,7 +595,7 @@ func TestClient_GetAuthorizationByUser_Error(t *testing.T) {
 	})
 	defer server.Close()
 
-	_, err := client.GetAuthorizationByUser(context.Background(), &GetAuthorizationByUserParams{UserID: "12345"})
+	_, err := client.GetAuthorizationByUser(context.Background(), &GetAuthorizationByUserParams{UserIDs: []string{"12345"}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Description

Three recently-added endpoints were mis-implemented; corrected against the official Twitch reference (the audit had flagged them as "unverified").

**Get Clips Download**
- Path `/clips/download` → **`/clips/downloads`**
- Now takes `*GetClipsDownloadParams` with `BroadcasterID`, `EditorID`, and `ClipIDs` (max 10) — previously a bare `id` query param
- `ClipDownload` is now `ClipID` / `LandscapeDownloadURL` / `PortraitDownloadURL` (was `ID` / `URL` / `ExpiresAt`)

**Create Clip From VOD**
- Path `/videos/clips` was already correct
- Parameters are now sent as **query parameters** — the endpoint reads them from the query string; they were incorrectly sent as a JSON body (so the request would have failed)

**Get Authorization By User**
- Path `/users/authorization` → **`/authorization/users`**
- Accepts up to 10 `user_id` values (`UserIDs []string`)
- `UserAuthorization` is now `UserID` / `UserName` / `UserLogin` / `Scopes` (removed the non-existent `ClientID`, renamed `Login` → `UserLogin`)

All **BREAKING** (signatures/field names change), but the previous forms could not have worked against the live API.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] Tests rewritten using the official example payloads (incl. `null` portrait URLs, multi-user authorization, query-param assertions for Create Clip From VOD)
- [x] `go build`, `go vet`, and the full suite pass

## Documentation
- [x] Updated `docs/clips.md` and `docs/users.md`