### PR TITLE
Add missing EventSub event fields and fix HypeTrainParticipant tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- EventSub event fields that were missing vs. the reference: `ChannelChatMessageEvent.IsSourceOnly`; `ChannelChatNotificationEvent.{IsSourceOnly,WatchStreak,Modiversary,SharedChatModiversary}` (+ `ChatNotificationWatchStreak`/`ChatNotificationModiversary` types); `ChannelModerateEvent.{SourceBroadcasterUserID,SourceBroadcasterUserLogin,SourceBroadcasterUserName,SharedChatUnban,SharedChatUntimeout}`; `ChannelGuestStarSessionEndEvent.{HostUserID,HostUserName,HostUserLogin}` and `ChannelGuestStarGuestUpdateEvent.{HostUserID,HostUserName,HostUserLogin}`
 
 ### Changed
 
 ### Fixed
+- **BREAKING:** `HypeTrainParticipant` JSON tags corrected to `broadcaster_user_id`/`broadcaster_user_login`/`broadcaster_user_name` (were `broadcaster_id`/`broadcaster_login`/`broadcaster_name`), matching the shared-train-participants payload
 
 ## [1.2.2] - 2026-04-23 ([#75](https://github.com/Its-donkey/kappopher/pull/75))
 

--- a/helix/eventsub_events.go
+++ b/helix/eventsub_events.go
@@ -344,9 +344,9 @@ const (
 
 // HypeTrainParticipant represents a participant in a shared hype train (v2 only).
 type HypeTrainParticipant struct {
-	BroadcasterID    string `json:"broadcaster_id"`
-	BroadcasterLogin string `json:"broadcaster_login"`
-	BroadcasterName  string `json:"broadcaster_name"`
+	BroadcasterID    string `json:"broadcaster_user_id"`
+	BroadcasterLogin string `json:"broadcaster_user_login"`
+	BroadcasterName  string `json:"broadcaster_user_name"`
 }
 
 // ChannelHypeTrainBeginEvent is sent when a Hype Train begins.
@@ -529,6 +529,7 @@ type ChannelChatMessageEvent struct {
 	SourceBroadcasterUserName  *string          `json:"source_broadcaster_user_name,omitempty"`
 	SourceMessageID            *string          `json:"source_message_id,omitempty"`
 	SourceBadges               []ChatEventBadge `json:"source_badges,omitempty"`
+	IsSourceOnly               *bool            `json:"is_source_only,omitempty"` // null if not in a shared chat session
 }
 
 // ChatEventMessage represents a chat message structure.
@@ -788,26 +789,33 @@ type ChannelUnbanRequestResolveEvent struct {
 type ChannelModerateEvent struct {
 	EventSubBroadcaster
 	EventSubModerator
-	Action            string                     `json:"action"`
-	Followers         *ModerateFollowers         `json:"followers,omitempty"`
-	Slow              *ModerateSlow              `json:"slow,omitempty"`
-	Vip               *ModerateUser              `json:"vip,omitempty"`
-	Unvip             *ModerateUser              `json:"unvip,omitempty"`
-	Mod               *ModerateUser              `json:"mod,omitempty"`
-	Unmod             *ModerateUser              `json:"unmod,omitempty"`
-	Ban               *ModerateBan               `json:"ban,omitempty"`
-	Unban             *ModerateUser              `json:"unban,omitempty"`
-	Timeout           *ModerateTimeout           `json:"timeout,omitempty"`
-	Untimeout         *ModerateUser              `json:"untimeout,omitempty"`
-	Raid              *ModerateRaid              `json:"raid,omitempty"`
-	Unraid            *ModerateRaid              `json:"unraid,omitempty"`
-	Delete            *ModerateDelete            `json:"delete,omitempty"`
-	AutomodTerms      *ModerateAutomodTerms      `json:"automod_terms,omitempty"`
-	UnbanRequest      *ModerateUnbanRequest      `json:"unban_request,omitempty"`
-	Warn              *ModerateWarn              `json:"warn,omitempty"`
-	SharedChatBan     *ModerateSharedChatBan     `json:"shared_chat_ban,omitempty"`
-	SharedChatTimeout *ModerateSharedChatTimeout `json:"shared_chat_timeout,omitempty"`
-	SharedChatDelete  *ModerateSharedChatDelete  `json:"shared_chat_delete,omitempty"`
+	// Source* fields identify the originating channel in a shared chat session
+	// (null when the action happens in the broadcaster's own channel).
+	SourceBroadcasterUserID    *string                    `json:"source_broadcaster_user_id,omitempty"`
+	SourceBroadcasterUserLogin *string                    `json:"source_broadcaster_user_login,omitempty"`
+	SourceBroadcasterUserName  *string                    `json:"source_broadcaster_user_name,omitempty"`
+	Action                     string                     `json:"action"`
+	Followers                  *ModerateFollowers         `json:"followers,omitempty"`
+	Slow                       *ModerateSlow              `json:"slow,omitempty"`
+	Vip                        *ModerateUser              `json:"vip,omitempty"`
+	Unvip                      *ModerateUser              `json:"unvip,omitempty"`
+	Mod                        *ModerateUser              `json:"mod,omitempty"`
+	Unmod                      *ModerateUser              `json:"unmod,omitempty"`
+	Ban                        *ModerateBan               `json:"ban,omitempty"`
+	Unban                      *ModerateUser              `json:"unban,omitempty"`
+	Timeout                    *ModerateTimeout           `json:"timeout,omitempty"`
+	Untimeout                  *ModerateUser              `json:"untimeout,omitempty"`
+	Raid                       *ModerateRaid              `json:"raid,omitempty"`
+	Unraid                     *ModerateRaid              `json:"unraid,omitempty"`
+	Delete                     *ModerateDelete            `json:"delete,omitempty"`
+	AutomodTerms               *ModerateAutomodTerms      `json:"automod_terms,omitempty"`
+	UnbanRequest               *ModerateUnbanRequest      `json:"unban_request,omitempty"`
+	Warn                       *ModerateWarn              `json:"warn,omitempty"`
+	SharedChatBan              *ModerateSharedChatBan     `json:"shared_chat_ban,omitempty"`
+	SharedChatUnban            *ModerateUser              `json:"shared_chat_unban,omitempty"`
+	SharedChatTimeout          *ModerateSharedChatTimeout `json:"shared_chat_timeout,omitempty"`
+	SharedChatUntimeout        *ModerateUser              `json:"shared_chat_untimeout,omitempty"`
+	SharedChatDelete           *ModerateSharedChatDelete  `json:"shared_chat_delete,omitempty"`
 }
 
 // ModerateFollowers represents followers-only mode settings.
@@ -1210,6 +1218,8 @@ type ChannelChatNotificationEvent struct {
 	Announcement               *ChatNotificationAnnouncement     `json:"announcement,omitempty"`
 	BitsBadgeTier              *ChatNotificationBitsBadgeTier    `json:"bits_badge_tier,omitempty"`
 	CharityDonation            *ChatNotificationCharityDonation  `json:"charity_donation,omitempty"`
+	WatchStreak                *ChatNotificationWatchStreak      `json:"watch_streak,omitempty"`
+	Modiversary                *ChatNotificationModiversary      `json:"modiversary,omitempty"`
 	SharedChatSub              *ChatNotificationSub              `json:"shared_chat_sub,omitempty"`
 	SharedChatResub            *ChatNotificationResub            `json:"shared_chat_resub,omitempty"`
 	SharedChatSubGift          *ChatNotificationSubGift          `json:"shared_chat_sub_gift,omitempty"`
@@ -1219,11 +1229,24 @@ type ChannelChatNotificationEvent struct {
 	SharedChatRaid             *ChatNotificationRaid             `json:"shared_chat_raid,omitempty"`
 	SharedChatPayItForward     *ChatNotificationPayItForward     `json:"shared_chat_pay_it_forward,omitempty"`
 	SharedChatAnnouncement     *ChatNotificationAnnouncement     `json:"shared_chat_announcement,omitempty"`
+	SharedChatModiversary      *ChatNotificationModiversary      `json:"shared_chat_modiversary,omitempty"`
 	SourceBroadcasterUserID    *string                           `json:"source_broadcaster_user_id,omitempty"`
 	SourceBroadcasterUserLogin *string                           `json:"source_broadcaster_user_login,omitempty"`
 	SourceBroadcasterUserName  *string                           `json:"source_broadcaster_user_name,omitempty"`
 	SourceMessageID            *string                           `json:"source_message_id,omitempty"`
 	SourceBadges               []ChatEventBadge                  `json:"source_badges,omitempty"`
+	IsSourceOnly               *bool                             `json:"is_source_only,omitempty"` // null if not in a shared chat session
+}
+
+// ChatNotificationWatchStreak represents the watch_streak notice in a chat notification.
+type ChatNotificationWatchStreak struct {
+	StreakCount          int `json:"streak_count"`
+	ChannelPointsAwarded int `json:"channel_points_awarded"`
+}
+
+// ChatNotificationModiversary represents the modiversary notice in a chat notification.
+type ChatNotificationModiversary struct {
+	Months int `json:"months"`
 }
 
 // ChatNotificationSub represents a sub notification.
@@ -1453,9 +1476,12 @@ type ChannelGuestStarSessionBeginEvent struct {
 // ChannelGuestStarSessionEndEvent is sent when a guest star session ends.
 type ChannelGuestStarSessionEndEvent struct {
 	EventSubBroadcaster
-	SessionID string    `json:"session_id"`
-	StartedAt time.Time `json:"started_at"`
-	EndedAt   time.Time `json:"ended_at"`
+	SessionID     string    `json:"session_id"`
+	StartedAt     time.Time `json:"started_at"`
+	EndedAt       time.Time `json:"ended_at"`
+	HostUserID    string    `json:"host_user_id"`
+	HostUserName  string    `json:"host_user_name"`
+	HostUserLogin string    `json:"host_user_login"`
 }
 
 // ChannelGuestStarGuestUpdateEvent is sent when a guest star guest is updated.
@@ -1463,6 +1489,9 @@ type ChannelGuestStarGuestUpdateEvent struct {
 	EventSubBroadcaster
 	EventSubModerator
 	SessionID        string `json:"session_id"`
+	HostUserID       string `json:"host_user_id"`
+	HostUserName     string `json:"host_user_name"`
+	HostUserLogin    string `json:"host_user_login"`
 	GuestUserID      string `json:"guest_user_id"`
 	GuestUserLogin   string `json:"guest_user_login"`
 	GuestUserName    string `json:"guest_user_name"`

--- a/helix/eventsub_events_test.go
+++ b/helix/eventsub_events_test.go
@@ -8,6 +8,68 @@ import (
 // Tests for eventsub_events.go event types using official Twitch API documentation payloads.
 // Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/
 
+// TestEventSubEvents_NewlyAddedFields verifies fields added to match the
+// official EventSub reference (shared-chat source fields, host_user_*,
+// is_source_only, watch_streak, modiversary).
+func TestEventSubEvents_NewlyAddedFields(t *testing.T) {
+	t.Run("moderate", func(t *testing.T) {
+		var e ChannelModerateEvent
+		if err := json.Unmarshal([]byte(`{
+			"broadcaster_user_id":"1","moderator_user_id":"2","action":"shared_chat_unban",
+			"source_broadcaster_user_id":"9","source_broadcaster_user_login":"src","source_broadcaster_user_name":"Src",
+			"shared_chat_unban":{"user_id":"5","user_login":"u","user_name":"U"}
+		}`), &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.SourceBroadcasterUserID == nil || *e.SourceBroadcasterUserID != "9" {
+			t.Errorf("source_broadcaster_user_id not decoded: %v", e.SourceBroadcasterUserID)
+		}
+		if e.SharedChatUnban == nil || e.SharedChatUnban.UserID != "5" {
+			t.Errorf("shared_chat_unban not decoded: %+v", e.SharedChatUnban)
+		}
+	})
+
+	t.Run("notification", func(t *testing.T) {
+		var e ChannelChatNotificationEvent
+		if err := json.Unmarshal([]byte(`{
+			"notice_type":"watch_streak","is_source_only":true,
+			"watch_streak":{"streak_count":3,"channel_points_awarded":350},
+			"modiversary":{"months":12}
+		}`), &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.WatchStreak == nil || e.WatchStreak.StreakCount != 3 || e.WatchStreak.ChannelPointsAwarded != 350 {
+			t.Errorf("watch_streak not decoded: %+v", e.WatchStreak)
+		}
+		if e.Modiversary == nil || e.Modiversary.Months != 12 {
+			t.Errorf("modiversary not decoded: %+v", e.Modiversary)
+		}
+		if e.IsSourceOnly == nil || !*e.IsSourceOnly {
+			t.Errorf("is_source_only not decoded: %v", e.IsSourceOnly)
+		}
+	})
+
+	t.Run("gueststar_host", func(t *testing.T) {
+		var e ChannelGuestStarSessionEndEvent
+		if err := json.Unmarshal([]byte(`{"session_id":"s","host_user_id":"7","host_user_name":"Host","host_user_login":"host"}`), &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.HostUserID != "7" || e.HostUserLogin != "host" || e.HostUserName != "Host" {
+			t.Errorf("host_user_* not decoded: %+v", e)
+		}
+	})
+
+	t.Run("chatmessage_source_only", func(t *testing.T) {
+		var e ChannelChatMessageEvent
+		if err := json.Unmarshal([]byte(`{"chatter_user_id":"1","message_id":"m","is_source_only":false}`), &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.IsSourceOnly == nil || *e.IsSourceOnly {
+			t.Errorf("is_source_only not decoded: %v", e.IsSourceOnly)
+		}
+	})
+}
+
 func TestHypeTrainBeginEvent_V1ToV2Conversion(t *testing.T) {
 	// Official Twitch v1 example from https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainbegin
 	// Modified is_golden_kappa_train to true for golden kappa test
@@ -191,8 +253,8 @@ func TestHypeTrainBeginEvent_V2ToV1Conversion(t *testing.T) {
 			}
 		],
 		"shared_train_participants": [
-			{"broadcaster_id": "111", "broadcaster_login": "user1", "broadcaster_name": "User1"},
-			{"broadcaster_id": "222", "broadcaster_login": "user2", "broadcaster_name": "User2"}
+			{"broadcaster_user_id": "111", "broadcaster_user_login": "user1", "broadcaster_user_name": "User1"},
+			{"broadcaster_user_id": "222", "broadcaster_user_login": "user2", "broadcaster_user_name": "User2"}
 		],
 		"level": 1,
 		"started_at": "2020-07-15T17:16:03.17106713Z",
@@ -216,6 +278,9 @@ func TestHypeTrainBeginEvent_V2ToV1Conversion(t *testing.T) {
 	}
 	if len(event3.SharedTrainParticipants) != 2 {
 		t.Errorf("expected 2 participants, got %d", len(event3.SharedTrainParticipants))
+	}
+	if event3.SharedTrainParticipants[0].BroadcasterID != "111" || event3.SharedTrainParticipants[0].BroadcasterLogin != "user1" {
+		t.Errorf("participant broadcaster_user_* not decoded: %+v", event3.SharedTrainParticipants[0])
 	}
 	if event3.IsGoldenKappaTrain {
 		t.Error("expected IsGoldenKappaTrain=false for shared train")


### PR DESCRIPTION
## Description

Verified every EventSub event struct in `eventsub_events.go` against the official EventSub reference (saved locally) via parallel review. Found and fixed:

**Tag bug**
- `HypeTrainParticipant` used `broadcaster_id`/`broadcaster_login`/`broadcaster_name`; the shared-train-participants payload uses **`broadcaster_user_id`/`_login`/`_name`**. (BREAKING tag change; the old tags never decoded.)

**Missing documented fields added**
- `ChannelChatMessageEvent.IsSourceOnly`
- `ChannelChatNotificationEvent.IsSourceOnly`, `.WatchStreak`, `.Modiversary`, `.SharedChatModiversary` (+ new `ChatNotificationWatchStreak` / `ChatNotificationModiversary` types)
- `ChannelModerateEvent.SourceBroadcasterUserID/Login/Name`, `.SharedChatUnban`, `.SharedChatUntimeout`
- `ChannelGuestStarSessionEndEvent` and `ChannelGuestStarGuestUpdateEvent`: `HostUserID/Name/Login`

Left intentionally unchanged (verified, not defects): fields the reference *under-documents* but are real (`gift_paid_upgrade.gifter_user_login`, `source_broadcaster_user_*` on chat clear/delete/hold/update), and the v1-only `last_contribution` kept for v1/v2 conversion.

Note: `AutomodSettingsUpdateEvent.aggression` (another missing field) is handled separately in #81.

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] Updated the hype-train shared-train test to the correct participant field names + asserts decoding
- [x] New `TestEventSubEvents_NewlyAddedFields` covers the moderate/notification/guest-star/chat-message additions
- [x] `go build`, `go vet`, and the full suite pass