### PR TITLE
Add channel.custom_power_up_redemption.add EventSub type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `channel.custom_power_up_redemption.add` EventSub subscription type (`EventSubTypeChannelCustomPowerUpRedemptionAdd`) and the `ChannelCustomPowerUpRedemptionAddEvent` / `EventSubCustomPowerUp` types
 
 ### Changed
 

--- a/helix/eventsub.go
+++ b/helix/eventsub.go
@@ -119,27 +119,28 @@ const (
 
 // EventSub subscription types - Channel
 const (
-	EventSubTypeChannelUpdate              = "channel.update"
-	EventSubTypeChannelFollow              = "channel.follow"
-	EventSubTypeChannelAdBreakBegin        = "channel.ad_break.begin"
-	EventSubTypeChannelBitsUse             = "channel.bits.use"
-	EventSubTypeChannelSubscribe           = "channel.subscribe"
-	EventSubTypeChannelSubscriptionEnd     = "channel.subscription.end"
-	EventSubTypeChannelSubscriptionGift    = "channel.subscription.gift"
-	EventSubTypeChannelSubscriptionMessage = "channel.subscription.message"
-	EventSubTypeChannelCheer               = "channel.cheer"
-	EventSubTypeChannelRaid                = "channel.raid"
-	EventSubTypeChannelBan                 = "channel.ban"
-	EventSubTypeChannelUnban               = "channel.unban"
-	EventSubTypeChannelUnbanRequestCreate  = "channel.unban_request.create"
-	EventSubTypeChannelUnbanRequestResolve = "channel.unban_request.resolve"
-	EventSubTypeChannelModerate            = "channel.moderate"
-	EventSubTypeChannelModeratorAdd        = "channel.moderator.add"
-	EventSubTypeChannelModeratorRemove     = "channel.moderator.remove"
-	EventSubTypeChannelVIPAdd              = "channel.vip.add"
-	EventSubTypeChannelVIPRemove           = "channel.vip.remove"
-	EventSubTypeChannelWarningSend         = "channel.warning.send"
-	EventSubTypeChannelWarningAcknowledge  = "channel.warning.acknowledge"
+	EventSubTypeChannelUpdate                     = "channel.update"
+	EventSubTypeChannelFollow                     = "channel.follow"
+	EventSubTypeChannelAdBreakBegin               = "channel.ad_break.begin"
+	EventSubTypeChannelBitsUse                    = "channel.bits.use"
+	EventSubTypeChannelCustomPowerUpRedemptionAdd = "channel.custom_power_up_redemption.add"
+	EventSubTypeChannelSubscribe                  = "channel.subscribe"
+	EventSubTypeChannelSubscriptionEnd            = "channel.subscription.end"
+	EventSubTypeChannelSubscriptionGift           = "channel.subscription.gift"
+	EventSubTypeChannelSubscriptionMessage        = "channel.subscription.message"
+	EventSubTypeChannelCheer                      = "channel.cheer"
+	EventSubTypeChannelRaid                       = "channel.raid"
+	EventSubTypeChannelBan                        = "channel.ban"
+	EventSubTypeChannelUnban                      = "channel.unban"
+	EventSubTypeChannelUnbanRequestCreate         = "channel.unban_request.create"
+	EventSubTypeChannelUnbanRequestResolve        = "channel.unban_request.resolve"
+	EventSubTypeChannelModerate                   = "channel.moderate"
+	EventSubTypeChannelModeratorAdd               = "channel.moderator.add"
+	EventSubTypeChannelModeratorRemove            = "channel.moderator.remove"
+	EventSubTypeChannelVIPAdd                     = "channel.vip.add"
+	EventSubTypeChannelVIPRemove                  = "channel.vip.remove"
+	EventSubTypeChannelWarningSend                = "channel.warning.send"
+	EventSubTypeChannelWarningAcknowledge         = "channel.warning.acknowledge"
 )
 
 // EventSub subscription types - Channel Chat
@@ -302,27 +303,28 @@ var EventSubTypeVersion = map[string]string{
 	EventSubTypeAutomodSettingsUpdate: "1",
 	EventSubTypeAutomodTermsUpdate:    "1",
 	// Channel
-	EventSubTypeChannelUpdate:              "2",
-	EventSubTypeChannelFollow:              "2",
-	EventSubTypeChannelAdBreakBegin:        "1",
-	EventSubTypeChannelBitsUse:             "1",
-	EventSubTypeChannelSubscribe:           "1",
-	EventSubTypeChannelSubscriptionEnd:     "1",
-	EventSubTypeChannelSubscriptionGift:    "1",
-	EventSubTypeChannelSubscriptionMessage: "1",
-	EventSubTypeChannelCheer:               "1",
-	EventSubTypeChannelRaid:                "1",
-	EventSubTypeChannelBan:                 "1",
-	EventSubTypeChannelUnban:               "1",
-	EventSubTypeChannelUnbanRequestCreate:  "1",
-	EventSubTypeChannelUnbanRequestResolve: "1",
-	EventSubTypeChannelModerate:            "2",
-	EventSubTypeChannelModeratorAdd:        "1",
-	EventSubTypeChannelModeratorRemove:     "1",
-	EventSubTypeChannelVIPAdd:              "1",
-	EventSubTypeChannelVIPRemove:           "1",
-	EventSubTypeChannelWarningSend:         "1",
-	EventSubTypeChannelWarningAcknowledge:  "1",
+	EventSubTypeChannelUpdate:                     "2",
+	EventSubTypeChannelFollow:                     "2",
+	EventSubTypeChannelAdBreakBegin:               "1",
+	EventSubTypeChannelBitsUse:                    "1",
+	EventSubTypeChannelCustomPowerUpRedemptionAdd: "1",
+	EventSubTypeChannelSubscribe:                  "1",
+	EventSubTypeChannelSubscriptionEnd:            "1",
+	EventSubTypeChannelSubscriptionGift:           "1",
+	EventSubTypeChannelSubscriptionMessage:        "1",
+	EventSubTypeChannelCheer:                      "1",
+	EventSubTypeChannelRaid:                       "1",
+	EventSubTypeChannelBan:                        "1",
+	EventSubTypeChannelUnban:                      "1",
+	EventSubTypeChannelUnbanRequestCreate:         "1",
+	EventSubTypeChannelUnbanRequestResolve:        "1",
+	EventSubTypeChannelModerate:                   "2",
+	EventSubTypeChannelModeratorAdd:               "1",
+	EventSubTypeChannelModeratorRemove:            "1",
+	EventSubTypeChannelVIPAdd:                     "1",
+	EventSubTypeChannelVIPRemove:                  "1",
+	EventSubTypeChannelWarningSend:                "1",
+	EventSubTypeChannelWarningAcknowledge:         "1",
 	// Chat
 	EventSubTypeChannelChatClear:             "1",
 	EventSubTypeChannelChatClearUserMessages: "1",

--- a/helix/eventsub_events.go
+++ b/helix/eventsub_events.go
@@ -730,6 +730,27 @@ type PowerUp struct {
 	Type string `json:"type"`
 }
 
+// ChannelCustomPowerUpRedemptionAddEvent is sent when a viewer redeems a
+// custom Bits Power-up (channel.custom_power_up_redemption.add).
+type ChannelCustomPowerUpRedemptionAddEvent struct {
+	EventSubBroadcaster
+	EventSubUser
+	ID            string                `json:"id"`
+	UserInput     string                `json:"user_input"`
+	Status        string                `json:"status"` // unknown, unfulfilled, fulfilled, canceled
+	CustomPowerUp EventSubCustomPowerUp `json:"custom_power_up"`
+	RedeemedAt    time.Time             `json:"redeemed_at"`
+}
+
+// EventSubCustomPowerUp is basic information about a custom Bits Power-up at
+// the time it was redeemed.
+type EventSubCustomPowerUp struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Bits   int    `json:"bits"`
+	Prompt string `json:"prompt"`
+}
+
 // VIP Events
 
 // ChannelVIPAddEvent is sent when a user is added as a VIP.

--- a/helix/eventsub_events_test.go
+++ b/helix/eventsub_events_test.go
@@ -878,3 +878,34 @@ func TestChannelPredictionBeginEvent(t *testing.T) {
 		t.Errorf("expected first outcome color=blue, got %s", event.Outcomes[0].Color)
 	}
 }
+
+// TestChannelCustomPowerUpRedemptionAddEvent verifies the
+// channel.custom_power_up_redemption.add event payload decodes.
+func TestChannelCustomPowerUpRedemptionAddEvent(t *testing.T) {
+	payload := []byte(`{
+		"id": "redemption-1",
+		"broadcaster_user_id": "1337", "broadcaster_user_login": "cool", "broadcaster_user_name": "Cool",
+		"user_id": "9001", "user_login": "viewer", "user_name": "Viewer",
+		"user_input": "go go go",
+		"status": "unfulfilled",
+		"custom_power_up": {"id": "pu-1", "title": "Hype", "bits": 100, "prompt": "Bring the hype"},
+		"redeemed_at": "2026-05-19T12:00:00Z"
+	}`)
+
+	var e ChannelCustomPowerUpRedemptionAddEvent
+	if err := json.Unmarshal(payload, &e); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if e.ID != "redemption-1" || e.BroadcasterUserID != "1337" || e.UserID != "9001" {
+		t.Errorf("core fields not decoded: %+v", e)
+	}
+	if e.Status != "unfulfilled" || e.UserInput != "go go go" {
+		t.Errorf("status/input not decoded: %+v", e)
+	}
+	if e.CustomPowerUp.ID != "pu-1" || e.CustomPowerUp.Bits != 100 || e.CustomPowerUp.Title != "Hype" {
+		t.Errorf("custom_power_up not decoded: %+v", e.CustomPowerUp)
+	}
+	if e.RedeemedAt.IsZero() {
+		t.Error("redeemed_at should be parsed")
+	}
+}


### PR DESCRIPTION
## Description

Adds the recently-released (2026-05) EventSub subscription type that was missing, verified against the official EventSub reference:

- `EventSubTypeChannelCustomPowerUpRedemptionAdd` constant (`channel.custom_power_up_redemption.add`, v1)
- `ChannelCustomPowerUpRedemptionAddEvent`: `id`, `user_input`, `status` (unknown/unfulfilled/fulfilled/canceled), `custom_power_up`, `redeemed_at` (+ embedded broadcaster/user)
- `EventSubCustomPowerUp`: `id`, `title`, `bits`, `prompt`

## Changelog
- [x] Updated CHANGELOG.md

## Testing
- [x] `TestChannelCustomPowerUpRedemptionAddEvent` decodes a reference-shaped payload
- [x] `go build`, `go vet`, and the full suite pass