### PR TITLE
Add conduit_id and subscription_id filters to GetEventSubSubscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `GetEventSubSubscriptionsParams.SubscriptionID` (`subscription_id`) and `GetEventSubSubscriptionsParams.ConduitID` (`conduit_id`) filters for `GetEventSubSubscriptions`
 
 ### Changed
 

--- a/docs/eventsub.md
+++ b/docs/eventsub.md
@@ -29,6 +29,16 @@ resp, err = client.GetEventSubSubscriptions(ctx, &helix.GetEventSubSubscriptions
     UserID: "12345",
 })
 
+// Filter to a single subscription by ID (if owned by the caller)
+resp, err = client.GetEventSubSubscriptions(ctx, &helix.GetEventSubSubscriptionsParams{
+    SubscriptionID: "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+})
+
+// Filter by conduit ID
+resp, err = client.GetEventSubSubscriptions(ctx, &helix.GetEventSubSubscriptionsParams{
+    ConduitID: "bfcfc993-26b1-b876-44d9-afe75a379dac",
+})
+
 // With pagination
 resp, err = client.GetEventSubSubscriptions(ctx, &helix.GetEventSubSubscriptionsParams{
     PaginationParams: &helix.PaginationParams{

--- a/helix/eventsub.go
+++ b/helix/eventsub.go
@@ -31,9 +31,11 @@ type EventSubTransport struct {
 
 // GetEventSubSubscriptionsParams contains parameters for GetEventSubSubscriptions.
 type GetEventSubSubscriptionsParams struct {
-	Status string // Filter by status
-	Type   string // Filter by subscription type
-	UserID string // Filter by user ID
+	Status         string // Filter by status
+	Type           string // Filter by subscription type
+	UserID         string // Filter by user ID
+	SubscriptionID string // Filter to a single subscription by ID (if owned by the caller)
+	ConduitID      string // Filter by conduit ID
 	*PaginationParams
 }
 
@@ -59,6 +61,12 @@ func (c *Client) GetEventSubSubscriptions(ctx context.Context, params *GetEventS
 		}
 		if params.UserID != "" {
 			q.Set("user_id", params.UserID)
+		}
+		if params.SubscriptionID != "" {
+			q.Set("subscription_id", params.SubscriptionID)
+		}
+		if params.ConduitID != "" {
+			q.Set("conduit_id", params.ConduitID)
 		}
 		addPaginationParams(q, params.PaginationParams)
 	}

--- a/helix/eventsub_test.go
+++ b/helix/eventsub_test.go
@@ -78,6 +78,8 @@ func TestClient_GetEventSubSubscriptions_WithFilters(t *testing.T) {
 		status := r.URL.Query().Get("status")
 		subType := r.URL.Query().Get("type")
 		userID := r.URL.Query().Get("user_id")
+		subscriptionID := r.URL.Query().Get("subscription_id")
+		conduitID := r.URL.Query().Get("conduit_id")
 
 		if status != "enabled" {
 			t.Errorf("expected status=enabled, got %s", status)
@@ -87,6 +89,12 @@ func TestClient_GetEventSubSubscriptions_WithFilters(t *testing.T) {
 		}
 		if userID != "12345" {
 			t.Errorf("expected user_id=12345, got %s", userID)
+		}
+		if subscriptionID != "sub-789" {
+			t.Errorf("expected subscription_id=sub-789, got %s", subscriptionID)
+		}
+		if conduitID != "conduit-abc" {
+			t.Errorf("expected conduit_id=conduit-abc, got %s", conduitID)
 		}
 
 		resp := EventSubResponse{
@@ -100,9 +108,11 @@ func TestClient_GetEventSubSubscriptions_WithFilters(t *testing.T) {
 	defer server.Close()
 
 	_, err := client.GetEventSubSubscriptions(context.Background(), &GetEventSubSubscriptionsParams{
-		Status: "enabled",
-		Type:   "channel.follow",
-		UserID: "12345",
+		Status:         "enabled",
+		Type:           "channel.follow",
+		UserID:         "12345",
+		SubscriptionID: "sub-789",
+		ConduitID:      "conduit-abc",
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds the two query filters Twitch has added to **Get EventSub Subscriptions** since this client was written:

- `subscription_id` — returns the single subscription matching the ID if owned by the caller (Twitch changelog 2025-05-09)
- `conduit_id` — filters subscriptions by conduit (Twitch changelog 2026-04-17)

Both are exposed as optional fields on `GetEventSubSubscriptionsParams` (`SubscriptionID`, `ConduitID`) and serialized into the query string only when non-empty, matching the existing `Status`/`Type`/`UserID` handling.

## Tests

Extended `TestClient_GetEventSubSubscriptions_WithFilters` to assert both new filters reach the request query string. Full `go test -short ./...` passes; `go vet` and `gofmt` clean.

Closes #69