### PR TITLE
Deprecate GetHypeTrainEvents — endpoint removed by Twitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GetEventSubSubscriptionsParams.SubscriptionID` (`subscription_id`) and `GetEventSubSubscriptionsParams.ConduitID` (`conduit_id`) filters for `GetEventSubSubscriptions`
 
 ### Changed
+- Deprecated `GetHypeTrainEvents`, `GetHypeTrainEventsParams`, `HypeTrainEvent`, and `HypeTrainEventData`: Twitch removed the "Get Hype Train Events" endpoint on 2026-02-05 (any live call now returns `404`). Use `GetHypeTrainStatus` instead. These will be removed in the next major release.
 
 ### Fixed
 

--- a/docs/hype-train.md
+++ b/docs/hype-train.md
@@ -4,7 +4,7 @@ title: Hype Train API
 description: Manage hype train events for Twitch channels.
 ---
 
-> **Note:** The Get Hype Train Events endpoint is deprecated and will be removed January 15, 2026. Use [EventSub](eventsub.md) for real-time hype train events instead.
+> **Note:** Twitch **removed** the Get Hype Train Events endpoint on 2026-02-05 in favor of [Get Hype Train Status](#gethypetrainstatus). Any live call now returns `404`. Use `GetHypeTrainStatus` (below) or [EventSub](eventsub.md) for real-time hype train events. `GetHypeTrainEvents` and its types remain for one release cycle and will be removed in the next major release.
 
 ## GetHypeTrainEvents
 
@@ -12,7 +12,7 @@ Get the broadcaster's hype train events.
 
 **Requires:** `channel:read:hype_train` scope
 
-**DEPRECATED:** This endpoint is deprecated. Use EventSub instead.
+**REMOVED BY TWITCH (2026-02-05):** This endpoint no longer exists and returns `404`. Use [`GetHypeTrainStatus`](#gethypetrainstatus) instead. Retained as deprecated for one release cycle.
 
 ```go
 resp, err := client.GetHypeTrainEvents(ctx, &helix.GetHypeTrainEventsParams{

--- a/helix/hype_train.go
+++ b/helix/hype_train.go
@@ -7,6 +7,10 @@ import (
 )
 
 // HypeTrainEvent represents a hype train event.
+//
+// Deprecated: Twitch removed the "Get Hype Train Events" endpoint (changelog
+// 2026-02-05). Use [Client.GetHypeTrainStatus] and the [HypeTrainStatus] type
+// instead.
 type HypeTrainEvent struct {
 	ID             string             `json:"id"`
 	EventType      string             `json:"event_type"`
@@ -16,6 +20,10 @@ type HypeTrainEvent struct {
 }
 
 // HypeTrainEventData contains the hype train event data.
+//
+// Deprecated: Twitch removed the "Get Hype Train Events" endpoint (changelog
+// 2026-02-05). Use [Client.GetHypeTrainStatus] and the [HypeTrainStatus] type
+// instead.
 type HypeTrainEventData struct {
 	ID               string                  `json:"id"`
 	BroadcasterID    string                  `json:"broadcaster_id"`
@@ -37,6 +45,9 @@ type HypeTrainContribution struct {
 }
 
 // GetHypeTrainEventsParams contains parameters for GetHypeTrainEvents.
+//
+// Deprecated: Twitch removed the "Get Hype Train Events" endpoint (changelog
+// 2026-02-05). Use [Client.GetHypeTrainStatus] instead.
 type GetHypeTrainEventsParams struct {
 	BroadcasterID string
 	*PaginationParams
@@ -44,7 +55,11 @@ type GetHypeTrainEventsParams struct {
 
 // GetHypeTrainEvents gets hype train events for a channel.
 // Requires: channel:read:hype_train scope.
-// Note: This endpoint is deprecated; use EventSub instead.
+//
+// Deprecated: Twitch removed the "Get Hype Train Events" endpoint (changelog
+// 2026-02-05) in favor of Get Hype Train Status. Any live call now returns 404.
+// Use [Client.GetHypeTrainStatus] instead. This will be removed in the next
+// major release.
 func (c *Client) GetHypeTrainEvents(ctx context.Context, params *GetHypeTrainEventsParams) (*Response[HypeTrainEvent], error) {
 	q := url.Values{}
 	q.Set("broadcaster_id", params.BroadcasterID)


### PR DESCRIPTION
## Summary

Twitch **removed** the Get Hype Train Events endpoint on 2026-02-05 in favor of Get Hype Train Status, so any live call to `GetHypeTrainEvents` now returns `404`.

Per #68, this marks the endpoint and its types as deprecated for one release cycle (full removal is a breaking change deferred to the next major release):

- Added Go `// Deprecated:` doc comments (recognized by `gopls`/`staticcheck`) to `GetHypeTrainEvents`, `GetHypeTrainEventsParams`, `HypeTrainEvent`, and `HypeTrainEventData`, each pointing at `GetHypeTrainStatus`.
- Corrected `docs/hype-train.md`, which previously claimed the endpoint *would* be removed on an inaccurate future date — it now states it was removed 2026-02-05 and returns `404`.
- CHANGELOG `### Changed` entry noting the deprecation and planned removal.

`GetHypeTrainStatus` (the replacement) already exists and is unchanged.

## Tests

No behavior change, so existing `hype_train_test.go` coverage stands (staticcheck's SA1019 ignores same-package deprecated usage, so those tests don't trip the linter). `go build`, `go vet`, `gofmt`, and full `go test -short ./...` all pass.

Closes #68