### PR TITLE
Surface existing subscription ID from 409 on CreateEventSubSubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GetEventSubSubscriptionsParams.SubscriptionID` (`subscription_id`) and `GetEventSubSubscriptionsParams.ConduitID` (`conduit_id`) filters for `GetEventSubSubscriptions`
+- `EventSubConflictError`, returned by `CreateEventSubSubscription` on a `409 Conflict`. Its `ExistingSubscriptionID` exposes the id of the already-existing subscription that Twitch reports in the 409 body; the underlying `*APIError` is wrapped (accessible via `errors.As`)
+- `APIError.Body` field exposing the raw error response body, so callers can read endpoint-specific fields the standard error envelope does not surface
 
 ### Changed
 

--- a/docs/eventsub.md
+++ b/docs/eventsub.md
@@ -156,6 +156,25 @@ if len(resp.Data) > 0 {
 }
 ```
 
+**Handling duplicate subscriptions (409 Conflict):**
+
+If a subscription already exists for the same type and condition, Twitch returns
+`409 Conflict` and includes the existing subscription's id in the response body.
+This is surfaced as an `*EventSubConflictError`, whose `ExistingSubscriptionID`
+holds that id:
+
+```go
+_, err := client.CreateEventSubSubscription(ctx, params)
+var conflict *helix.EventSubConflictError
+if errors.As(err, &conflict) {
+    fmt.Printf("Already subscribed; existing subscription id: %s\n",
+        conflict.ExistingSubscriptionID)
+}
+```
+
+The underlying `*helix.APIError` remains accessible via `errors.As` (and through
+`conflict.APIError`), so the status code and raw error body are still available.
+
 **Sample Response:**
 ```json
 {

--- a/helix/client.go
+++ b/helix/client.go
@@ -210,6 +210,10 @@ type ErrorResponse struct {
 	Error   string `json:"error"`
 	Status  int    `json:"status"`
 	Message string `json:"message"`
+	// ID is populated by endpoints that return an identifier in the error body,
+	// e.g. Create EventSub Subscription returns the existing subscription's id
+	// on a 409 Conflict.
+	ID string `json:"id"`
 }
 
 // APIError represents a Twitch API error.
@@ -217,6 +221,9 @@ type APIError struct {
 	StatusCode int
 	ErrorType  string
 	Message    string
+	// Body is the raw error response body, retained so callers can extract
+	// endpoint-specific fields the standard envelope does not surface.
+	Body []byte
 }
 
 func (e *APIError) Error() string {
@@ -469,12 +476,14 @@ func (c *Client) doOnceWithResponse(ctx context.Context, req *Request, result in
 				StatusCode: resp.StatusCode,
 				ErrorType:  "unknown",
 				Message:    string(body),
+				Body:       body,
 			}
 		}
 		return mwResp, &APIError{
 			StatusCode: resp.StatusCode,
 			ErrorType:  errResp.Error,
 			Message:    errResp.Message,
+			Body:       body,
 		}
 	}
 

--- a/helix/eventsub.go
+++ b/helix/eventsub.go
@@ -2,6 +2,10 @@ package helix
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -95,11 +99,44 @@ type CreateEventSubTransport struct {
 	ConduitID string `json:"conduit_id,omitempty"`
 }
 
+// EventSubConflictError is returned by CreateEventSubSubscription when a
+// subscription already exists for the requested type and condition combination
+// (HTTP 409). ExistingSubscriptionID is the id of the conflicting subscription,
+// which Twitch includes in the 409 response body. The underlying *APIError is
+// wrapped, so errors.As and the StatusCode/Body fields remain accessible.
+type EventSubConflictError struct {
+	ExistingSubscriptionID string
+	*APIError
+}
+
+func (e *EventSubConflictError) Error() string {
+	if e.ExistingSubscriptionID != "" {
+		return fmt.Sprintf("eventsub subscription already exists (existing id %s): %s", e.ExistingSubscriptionID, e.APIError.Error())
+	}
+	return fmt.Sprintf("eventsub subscription already exists: %s", e.APIError.Error())
+}
+
+// Unwrap returns the underlying *APIError.
+func (e *EventSubConflictError) Unwrap() error { return e.APIError }
+
 // CreateEventSubSubscription creates an EventSub subscription.
 // Requires: App access token.
+//
+// If a subscription already exists for the same type and condition, Twitch
+// returns 409 Conflict; this is surfaced as an [EventSubConflictError] whose
+// ExistingSubscriptionID holds the id of the conflicting subscription.
 func (c *Client) CreateEventSubSubscription(ctx context.Context, params *CreateEventSubSubscriptionParams) (*EventSubSubscription, error) {
 	var resp EventSubResponse
 	if err := c.post(ctx, "/eventsub/subscriptions", nil, params, &resp); err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+			conflict := &EventSubConflictError{APIError: apiErr}
+			var er ErrorResponse
+			if json.Unmarshal(apiErr.Body, &er) == nil {
+				conflict.ExistingSubscriptionID = er.ID
+			}
+			return nil, conflict
+		}
 		return nil, err
 	}
 	if len(resp.Data) == 0 {

--- a/helix/eventsub_test.go
+++ b/helix/eventsub_test.go
@@ -3,6 +3,7 @@ package helix
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -758,5 +759,52 @@ func TestClient_DeleteEventSubSubscription_Error(t *testing.T) {
 	err := client.DeleteEventSubSubscription(context.Background(), "nonexistent")
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestClient_CreateEventSubSubscription_Conflict(t *testing.T) {
+	const existingID = "26b1c993-bfcf-44d9-b876-379dacafe75a"
+	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{
+			"error": "Conflict",
+			"status": 409,
+			"message": "subscription already exists",
+			"id": "` + existingID + `"
+		}`))
+	})
+	defer server.Close()
+
+	_, err := client.CreateEventSubSubscription(context.Background(), &CreateEventSubSubscriptionParams{
+		Type:    "channel.follow",
+		Version: "2",
+		Condition: map[string]string{
+			"broadcaster_user_id": "12345",
+			"moderator_user_id":   "12345",
+		},
+		Transport: CreateEventSubTransport{
+			Method:    "websocket",
+			SessionID: "session123",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var conflict *EventSubConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *EventSubConflictError, got %T: %v", err, err)
+	}
+	if conflict.ExistingSubscriptionID != existingID {
+		t.Errorf("ExistingSubscriptionID = %q, want %q", conflict.ExistingSubscriptionID, existingID)
+	}
+
+	// The underlying *APIError must remain accessible via errors.As.
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatal("expected wrapped *APIError to be accessible via errors.As")
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusConflict)
 	}
 }


### PR DESCRIPTION
## Summary

Twitch updated the **Create EventSub Subscription** endpoint (changelog 2026-04-17) to return the id of the *existing* subscription in the body of a `409 Conflict`. The Twitch reference confirms: *"A subscription already exists for the specified event type and condition combination. The id value in the error response represents the existing EventSub subscription."* Previously this client discarded the 409 body, so callers had no way to find the conflicting subscription.

### Changes
- **`APIError.Body []byte`** — the raw error response body is now retained on `APIError`, so callers can read endpoint-specific fields the standard `{error,status,message}` envelope doesn't surface. Generic and broadly useful.
- **`ErrorResponse.ID`** — captures the `id` Twitch puts in the error body.
- **`EventSubConflictError`** — `CreateEventSubSubscription` now translates a 409 into this typed error, whose `ExistingSubscriptionID` holds the conflicting subscription's id. It embeds/wraps the `*APIError` (`Unwrap`), so `errors.As` and `StatusCode`/`Body` stay accessible.

### Usage
```go
_, err := client.CreateEventSubSubscription(ctx, params)
var conflict *helix.EventSubConflictError
if errors.As(err, &conflict) {
    // conflict.ExistingSubscriptionID is the existing subscription
}
```

## Tests

`TestClient_CreateEventSubSubscription_Conflict` mocks a 409 with an `id` body and asserts both that `errors.As` yields `*EventSubConflictError` with the right `ExistingSubscriptionID` and that the wrapped `*APIError` (status code) remains reachable. Docs updated in `docs/eventsub.md`. `go build`, `go vet`, `gofmt`, and full `go test -short ./...` all pass.

Closes #74