### PR TITLE
Fix lint CI: upgrade to golangci-lint v2 for Go 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: '1.26'
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped the Go version to 1.26 in `go.mod`, and updated the CI workflows (test matrix, lint, build, coverage, and release) to run on Go 1.26
+- CI: upgraded the lint job to golangci-lint v2 (`golangci-lint-action@v8`); the previous v1 line was built with Go 1.24 and refused to run against a `go 1.26` module. Cleared the findings it then surfaced (unchecked `w.Write` results in the mock integration test, redundant embedded-field selectors in the `NullableTime` test)
 - Modernized the codebase to Go 1.26 idioms: `interface{}` → `any`, `strings.SplitSeq`/`strings.Cut`/`strings.CutPrefix`, `maps.Copy`, `slices.Contains`, `sync.WaitGroup.Go`, and the `max` builtin. `LoggingMiddleware`'s logger parameter is now `func(format string, args ...any)` (identical to the previous `...interface{}`)
 - **BREAKING:** Optional timestamp fields that Twitch may return empty now use `NullableTime` instead of `time.Time`: `AdSchedule.{NextAdAt,LastAdAt,SnoozeRefreshAt}`, `SnoozeNextAdResponse.{SnoozeRefreshAt,NextAdAt}`, `BannedUser.ExpiresAt`, `BanUserResponse.EndTime`, `BlockedTerm.ExpiresAt`, `Poll.EndedAt`, `Prediction.{EndedAt,LockedAt}`, `SearchChannel.StartedAt`
 - Removed no-op `omitempty` from value-type `time.Time` JSON fields (a struct is never "empty" to the JSON encoder)

--- a/helix/mock_integration_test.go
+++ b/helix/mock_integration_test.go
@@ -247,12 +247,12 @@ func TestMockAPI_ClientAgainstMockServer(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users":
-			w.Write([]byte(`{"data":[{"id":"11138301","login":"testuser","display_name":"TestUser","type":"","broadcaster_type":"partner","description":"","created_at":"2026-02-18T07:00:03Z","profile_image_url":"","offline_image_url":"","view_count":0}]}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"11138301","login":"testuser","display_name":"TestUser","type":"","broadcaster_type":"partner","description":"","created_at":"2026-02-18T07:00:03Z","profile_image_url":"","offline_image_url":"","view_count":0}]}`))
 		case "/streams":
-			w.Write([]byte(`{"data":[{"id":"123456","user_id":"11138301","user_login":"testuser","user_name":"TestUser","game_id":"12345","game_name":"TestGame","type":"live","title":"Test Stream","viewer_count":100,"started_at":"2026-02-18T07:00:03Z","language":"en","thumbnail_url":"","is_mature":false}],"pagination":{}}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"123456","user_id":"11138301","user_login":"testuser","user_name":"TestUser","game_id":"12345","game_name":"TestGame","type":"live","title":"Test Stream","viewer_count":100,"started_at":"2026-02-18T07:00:03Z","language":"en","thumbnail_url":"","is_mature":false}],"pagination":{}}`))
 		default:
 			w.WriteHeader(404)
-			w.Write([]byte(`{"error":"Not Found","status":404,"message":"endpoint not found"}`))
+			_, _ = w.Write([]byte(`{"error":"Not Found","status":404,"message":"endpoint not found"}`))
 		}
 	}))
 	defer mockServer.Close()

--- a/helix/time_test.go
+++ b/helix/time_test.go
@@ -36,10 +36,10 @@ func TestNullableTime_Unmarshal(t *testing.T) {
 			if nt.Valid != tt.wantValid {
 				t.Errorf("Valid = %v, want %v", nt.Valid, tt.wantValid)
 			}
-			if tt.wantValid && !nt.Time.Equal(tt.wantTime) {
+			if tt.wantValid && !nt.Equal(tt.wantTime) {
 				t.Errorf("Time = %v, want %v", nt.Time, tt.wantTime)
 			}
-			if !tt.wantValid && !nt.Time.IsZero() {
+			if !tt.wantValid && !nt.IsZero() {
 				t.Errorf("Time = %v, want zero", nt.Time)
 			}
 		})


### PR DESCRIPTION
## Problem

The `Tests` workflow's **Lint** job has been failing on `test` since the Go 1.26 bump merged (#92):

```
can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.26)
golangci-lint exit with code 3
```

The job pinned `version: latest`, which resolves to golangci-lint **v1.64.8** — the v1 line tops out built with go1.24, and golangci-lint refuses to run when its build-Go is older than the module's `go` directive (now 1.26). Test/Build/Coverage all passed; only Lint was red.

## Fix

- Upgrade the lint step to **`golangci/golangci-lint-action@v8`**, which installs golangci-lint **v2** (latest is v2.12.2, built with go1.26.2).
- v2 then ran for the first time (the broken v1 run never got past config load) and surfaced two pre-existing findings, now fixed:
  - `mock_integration_test.go`: check `w.Write` return values (errcheck ×3)
  - `time_test.go`: drop redundant embedded-field selectors — `nt.Time.Equal`→`nt.Equal`, `nt.Time.IsZero`→`nt.IsZero` (staticcheck QF1008 ×2)

## Verification

Locally with golangci-lint **v2.12.2 (go1.26.2)**: `golangci-lint run ./...` → **0 issues**. `go build`, `go vet`, `go test -short ./...` all pass.

Closes the lint failure on the #92 merge.