### PR TITLE
CI: add stable 'Test Pass' gate for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,24 @@ jobs:
       - name: Run tests
         run: go test -v -race ./...
 
+  # Stable aggregate gate for branch protection. Its name ("Test Pass") does not
+  # change when the Go version matrix changes, so the required status check never
+  # goes stale on a Go bump (unlike the per-version "Test (1.xx)" job names).
+  # Require this context in branch protection instead of the matrix jobs.
+  test-pass:
+    name: Test Pass
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the test matrix succeeded
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "::error::Test matrix result was '${{ needs.test.result }}'"
+            exit 1
+          fi
+          echo "All Test matrix jobs passed."
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- CI: added a stable `Test Pass` aggregate job (gates on the `Test` matrix) so branch protection can require a version-independent status check. This prevents the required check from going stale whenever the Go version matrix changes (as happened when `Test (1.24)` was retired for `Test (1.26)`).
 
 ### Fixed
 


### PR DESCRIPTION
## Why

When the Go matrix moved to 1.26, the per-version job name changed from `Test (1.24)` to `Test (1.26)`. The **Main Branch Protection** ruleset still requires the literal context `Test (1.24)`, which now never reports — so the promotion PR (#94) is stuck on *"Expected — Waiting for status to be reported"*. Any future Go bump would re-break it the same way.

## What

Adds a small aggregate gate job:

```yaml
test-pass:
  name: Test Pass
  needs: [test]
  if: always()
  runs-on: ubuntu-latest
  steps:
    - run: |
        if [ "${{ needs.test.result }}" != "success" ]; then
          echo "::error::Test matrix result was '${{ needs.test.result }}'"; exit 1
        fi
```

Its name (`Test Pass`) is **version-independent**, so branch protection can require it once and it never goes stale across Go upgrades. `if: always()` ensures it reports a real pass/fail (not "skipped") even when the matrix fails.

## Required follow-up (manual, admin)

After this lands, update the **Main Branch Protection** ruleset's required status checks: **remove `Test (1.24)`, add `Test Pass`**. (`Build` and `check-source-branch` stay as-is.) That's the one-time edit that both unblocks #94 and makes the gate durable.

YAML validated; all jobs parse.