### PR TITLE
Apply go fix: use strings.Builder in whispers test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CI: added a stable `Test Pass` aggregate job (gates on the `Test` matrix) so branch protection can require a version-independent status check. This prevents the required check from going stale whenever the Go version matrix changes (as happened when `Test (1.24)` was retired for `Test (1.26)`).
+- Applied `go fix`: rewrote an in-loop string concatenation in `whispers_test.go` to use `strings.Builder` (Go 1.26 fixer). Test-only; no library behavior change.
 
 ### Fixed
 

--- a/helix/whispers_test.go
+++ b/helix/whispers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -50,15 +51,15 @@ func TestClient_SendWhisper(t *testing.T) {
 }
 
 func TestClient_SendWhisper_LongMessage(t *testing.T) {
-	longMessage := ""
+	var longMessage strings.Builder
 	for range 100 {
-		longMessage += "This is a long message. "
+		longMessage.WriteString("This is a long message. ")
 	}
 
 	client, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
 		var params SendWhisperParams
 		_ = json.NewDecoder(r.Body).Decode(&params)
-		if params.Message != longMessage {
+		if params.Message != longMessage.String() {
 			t.Errorf("message mismatch")
 		}
 
@@ -69,7 +70,7 @@ func TestClient_SendWhisper_LongMessage(t *testing.T) {
 	err := client.SendWhisper(context.Background(), &SendWhisperParams{
 		FromUserID: "12345",
 		ToUserID:   "67890",
-		Message:    longMessage,
+		Message:    longMessage.String(),
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Ran `go fix ./...` under Go 1.26. The only change it made: the Go 1.26 `strings.Builder` fixer rewrote an in-loop string concatenation in `TestClient_SendWhisper_LongMessage` (`whispers_test.go`).

```go
// before
longMessage := ""
for range 100 { longMessage += "This is a long message. " }

// after
var longMessage strings.Builder
for range 100 { longMessage.WriteString("This is a long message. ") }
// ...use longMessage.String()
```

Test-only; no library/runtime behavior change. Avoids the quadratic-allocation pattern `go vet`/fixers flag.

## Verification

`go build`, `go vet`, `gofmt -l` (clean), `golangci-lint run` (**0 issues**, v2.12.2), and `go test -short ./...` all pass.